### PR TITLE
Add Gemfile for dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 pkg
 doc
+.bundle
+Gemfile.lock
 ruby/server/wb_test/
 *.log*
 *.route*

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,17 @@
+source "https://rubygems.org"
+
+gem 'eventmachine'
+
+# Back-end storages
+group :tokyocabinet do
+  gem 'tokyocabinet', :git => 'https://github.com/roma/tokyocabinet-ruby.git'
+end
+
+group :gdbm do
+  gem 'ffi'
+  gem 'gdbm'
+end
+
+group :sqlite3 do
+  gem 'sqlite3'
+end


### PR DESCRIPTION
I add Gemfile for ROMA. I assumed following usages. Please check it.
1. Install all gems as global gem.

```
bundle install
```
1. Install gems to .bundle directory and install only tokyocabinet for back-end storage.

```
bundle install --path=.bundle --without gdbm sqlite3
```
