### PR TITLE
Add Groonga based storage backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,10 @@ group :sqlite3 do
   gem 'sqlite3'
 end
 
+group :groonga do
+  gem 'rroonga'
+end
+
 group :test do
   gem 'test-unit'
 end

--- a/ruby/server/lib/roma/storage/groonga_storage.rb
+++ b/ruby/server/lib/roma/storage/groonga_storage.rb
@@ -1,0 +1,101 @@
+require 'groonga'
+require 'roma/storage/basic_storage'
+
+module Roma
+  module Storage
+
+    class GroongaStorage < BasicStorage
+      def initialize
+        super
+        @ext_name = 'grn'
+      end
+
+      def get_stat
+        ret = super
+        @hdb.each_with_index do |hdb, i|
+          ret["storage[#{i}].path"] = File.expand_path(hdb.path)
+          ret["storage[#{i}].rnum"] = hdb.rnum
+        end
+        ret
+      end
+
+      private
+      def open_db(fname)
+        hdb = GroongaHash.new(fname)
+        hdb.open
+        hdb
+      end
+
+      def close_db(hdb)
+        hdb.close
+      end
+
+      class GroongaHash
+        def initialize(fname)
+          @fname = fname
+        end
+
+        def path
+          @hash.path
+        end
+
+        def put(key, value)
+          record = @hash.add(key)
+          @value[record.id] = value
+        end
+
+        def get(key)
+          record = @hash[key]
+          return nil if record.nil?
+          @value[record.id]
+        end
+
+        def out(key)
+          record = @hash[key]
+          if record
+            record.delete
+            true
+          else
+            false
+          end
+        end
+
+        def rnum
+          @hash.count
+        end
+
+        def each
+          @hash.each do |record|
+            yield(record.key, @value[record.id])
+          end
+        end
+
+        def open
+          @context = Groonga::Context.new(:encoding => :none)
+          if File.exist?(@fname)
+            @database = Groonga::Database.new(@fname, :context => @context)
+          else
+            @database = Groonga::Database.create(:context => @context,
+                                                 :path => @fname)
+            Groonga::Schema.define(:context => @context) do |schema|
+              schema.create_table("hash",
+                                  :type => :hash,
+                                  :key_type => "ShortText") do |table|
+                table.text("value")
+              end
+            end
+          end
+
+          @hash = @context["hash"]
+          @value = @hash.column("value")
+        end
+
+        def close
+          @database.close
+          @context.close
+          @hash = @value = @database = @context = nil
+        end
+      end
+    end # class GroongaStorage
+  end # module Storage
+end # module Roma

--- a/ruby/server/test/t_storage.rb
+++ b/ruby/server/test/t_storage.rb
@@ -4,6 +4,7 @@ require 'roma/storage/tc_storage'
 require 'roma/storage/dbm_storage'
 require 'roma/storage/rh_storage'
 require 'roma/storage/sqlite3_storage'
+require 'roma/storage/groonga_storage'
 
 module StorageTests
   def ndat
@@ -835,5 +836,26 @@ class TCMemStorageTest < Test::Unit::TestCase
     @st.vn_list = [0,1,2,3,4,5,6,7,8,9]
     @st.storage_path = 'storage_test'
     @st.opendb
+  end
+end
+
+class GroongaStorageTest < Test::Unit::TestCase
+  include StorageTests
+
+  def storage_path
+    'groonga_storage_test'
+  end
+
+  def setup
+    rmtestdir(storage_path)
+    @st = Roma::Storage::GroongaStorage.new
+    @st.vn_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    @st.storage_path = storage_path
+    @st.opendb
+  end
+
+  def teardown
+    @st.closedb
+    rmtestdir(storage_path)
   end
 end


### PR DESCRIPTION
What about adding Groonga based storage backend? It is fast like Tokyo Cabinet, has full-text search feature and is well maintained. We may be able to implement "value full-text searchable feature" as a plugin based on the Groonga based storage backend.

[Groonga](http://groonga.org/) is a full-text search engine but it also has column oriented storage feature. So we can use Groonga as key value store.

Here is a benchmark article in Japanese: [GroongaとTokyoCabinetのHash表のベンチマークについて](http://blog.createfield.com/entry/2014/07/26/233617)

It says that Groonga is faster than Tokyo Cabinet.

Note: The benchmark is not the same usage of this pull request. The benchmark stores data to "value" location in hash table. ("value" location is fixed size data store location.) This pull request implementation uses "column" for storing data. "column" is slower than "value" location but "column" supports type (such as text, integer and geo location) and variable size data. Variable size data is suitable for text data.

Here is another benchmark in Rroonga repository: https://github.com/ranguba/rroonga/blob/master/benchmark/read-write-many-small-items.rb#L8-17

It uses "column" not "value" location for storing data.

It says that (file based) Groonga is slower than memory based Tokyo Cabinet but faster than file based Tokyo Cabinet.
