### PR TITLE
Declare the license of ROMA in gemspec file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,6 +50,7 @@ SPEC = Gem::Specification.new do |s|
   s.homepage = 'http://code.google.com/p/roma-prj/'
   s.name = "roma"
   s.version = CURRENT_VERSION
+  s.licnese = 'GPL-3.0'
   s.summary = "ROMA server"
   s.description = <<-EOF
     ROMA server


### PR DESCRIPTION
I know there is LICENSE file in this repository and the file is distributed with the gem package. 
but in rubygems.org, ROMA looks like no license :feelsgood: 

![roma_rubygems](https://cloud.githubusercontent.com/assets/124871/5560090/1bda421c-8db5-11e4-97f6-11628dd58268.png)
