### PR TITLE
Define gemspec file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,25 +1,8 @@
 source "https://rubygems.org"
 
-gem 'eventmachine'
+gemspec
 
 # Back-end storages
 group :tokyocabinet do
   gem 'tokyocabinet', :git => 'https://github.com/roma/tokyocabinet-ruby.git'
-end
-
-group :gdbm do
-  gem 'ffi'
-  gem 'gdbm'
-end
-
-group :sqlite3 do
-  gem 'sqlite3'
-end
-
-group :groonga do
-  gem 'rroonga'
-end
-
-group :test do
-  gem 'test-unit'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -14,8 +14,6 @@ RDOC_OPTIONS = [
                 "-c UTF-8",
                ]
 
-require File.expand_path(File.join('ruby', 'server', 'lib', 'roma', 'version'), File.dirname(__FILE__))
-
 Rake::RDocTask.new("doc") { |rdoc|
   rdoc.rdoc_dir = 'doc'
   rdoc.title = "ROMA documents"

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,5 @@
-require 'rubygems'
+require 'bundler/gem_tasks'
 require 'rake'
-
-begin
-  require 'rubygems/package_task'
-  PackageTask = Gem::PackageTask
-rescue LoadError
-  require 'rake/gempackagetask'
-  PackageTask = Rake::GemPackageTask
-end
 
 begin
   require 'rdoc/task'
@@ -22,59 +14,7 @@ RDOC_OPTIONS = [
                 "-c UTF-8",
                ]
 
-# gem tasks
-base = 'ruby/server/'
-PKG_FILES = FileList[
-  '[A-Z]*',
-  base + 'bin/**/*',
-  base + 'lib/**/*',
-  base + 'test/**/*.rb',
-  base + 'spec/**/*.rb',
-  base + 'doc/**/*',
-  base + 'examples/**/*',
-]
-
-EXEC_TABLE = Dir.entries(base + 'bin').reject{ |d| d =~ /^\.+$/ || d =~ /^sample_/ }
-
 require File.expand_path(File.join('ruby', 'server', 'lib', 'roma', 'version'), File.dirname(__FILE__))
-VER_NUM = Roma::VERSION
-
-if VER_NUM =~ /([0-9.p-]+)$/
-  CURRENT_VERSION = $1.delete("-")
-else
-  CURRENT_VERSION = "0.0.0"
-end
-
-SPEC = Gem::Specification.new do |s|
-  s.authors = ["Junji Torii", "Hiroki Matsue"]
-  s.homepage = 'http://code.google.com/p/roma-prj/'
-  s.name = "roma"
-  s.version = CURRENT_VERSION
-  s.licnese = 'GPL-3.0'
-  s.summary = "ROMA server"
-  s.description = <<-EOF
-    ROMA server
-  EOF
-  s.files = PKG_FILES.to_a
-
-  # Use these for libraries.
-  s.require_path = base + 'lib'
-
-  # Use these for applications.
-  s.bindir = base + "bin"
-  s.executables = EXEC_TABLE
-  s.default_executable = "romad"
-
-  s.has_rdoc = true
-  s.rdoc_options.concat RDOC_OPTIONS
-  s.extra_rdoc_files = ["README", "CHANGELOG"]
-
-  s.add_dependency('eventmachine')
-end
-
-package_task = PackageTask.new(SPEC) do |pkg|
-end
-
 
 Rake::RDocTask.new("doc") { |rdoc|
   rdoc.rdoc_dir = 'doc'

--- a/roma.gemspec
+++ b/roma.gemspec
@@ -1,0 +1,50 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib)
+
+require 'lib/roma/version'
+
+Gem::Specification.new do |s|
+  s.authors = ["Junji Torii", "Hiroki Matsue"]
+  s.homepage = 'http://code.google.com/p/roma-prj/'
+  s.name = "roma"
+  s.version = Roma::VERSION
+  s.licnese = 'GPL-3.0'
+  s.summary = "ROMA server"
+  s.description = <<-EOF
+    ROMA server
+  EOF
+  s.files = FileList[
+    '[A-Z]*',
+    'bin/**/*',
+    'lib/**/*',
+    'test/**/*.rb',
+    'spec/**/*.rb',
+    'doc/**/*',
+    'examples/**/*',
+  ]
+
+  # TODO: Specify Ruby version roma-1.1.0 must support
+  # s.required_ruby_version = '>= 2.0.0'
+
+  # Use these for libraries.
+  s.require_path = 'lib'
+
+  # Use these for applications.
+  s.bindir = "bin"
+  s.executables = Dir.entries(base + 'bin').reject{ |d| d =~ /^\.+$/ || d =~ /^sample_/ }
+
+  s.default_executable = "romad"
+
+  s.has_rdoc = true
+  s.rdoc_options.concat RDOC_OPTIONS
+  s.extra_rdoc_files = ["README", "CHANGELOG"]
+
+  # TODO: for each gem, which version does rom depend on?
+  s.add_dependency 'eventmachine'
+
+  s.add_development_dependency 'ffi'
+  s.add_development_dependency 'gdbm'
+  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'rroonga'
+  s.add_development_dependency 'test-unit'
+end

--- a/roma.gemspec
+++ b/roma.gemspec
@@ -1,14 +1,15 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib)
 
-require 'lib/roma/version'
+require 'rake'
+require 'roma/version'
 
 Gem::Specification.new do |s|
   s.authors = ["Junji Torii", "Hiroki Matsue"]
   s.homepage = 'http://code.google.com/p/roma-prj/'
   s.name = "roma"
   s.version = Roma::VERSION
-  s.licnese = 'GPL-3.0'
+  s.license = 'GPL-3.0'
   s.summary = "ROMA server"
   s.description = <<-EOF
     ROMA server
@@ -31,12 +32,17 @@ Gem::Specification.new do |s|
 
   # Use these for applications.
   s.bindir = "bin"
-  s.executables = Dir.entries(base + 'bin').reject{ |d| d =~ /^\.+$/ || d =~ /^sample_/ }
+  s.executables = Dir.entries('bin').reject{ |d| d =~ /^\.+$/ || d =~ /^sample_/ }
 
   s.default_executable = "romad"
 
   s.has_rdoc = true
-  s.rdoc_options.concat RDOC_OPTIONS
+  s.rdoc_options = [
+                '--line-numbers',
+                '--inline-source',
+                "--main", "README",
+                "-c UTF-8"
+               ]
   s.extra_rdoc_files = ["README", "CHANGELOG"]
 
   # TODO: for each gem, which version does rom depend on?
@@ -47,4 +53,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rroonga'
   s.add_development_dependency 'test-unit'
+  s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
This adds `roma.gemspec` to define specifications of roma. 

The gemfile allows us to define

* `required_ruby_version`: Declare the versions of ruby required
* `add_development_dependency`: Declare the gems required for developing roma.

and `gemfile` in Gemfile loads gems on which roma depends defined in the gemspec file. 