### PR TITLE
remove booting error in the log

### DIFF
--- a/lib/roma/messaging/con_pool.rb
+++ b/lib/roma/messaging/con_pool.rb
@@ -33,6 +33,16 @@ module Roma
         nil
       end
 
+      def check_connection(ap)
+        host, port = ap.split(/[:_]/)
+        addr = DNSCache.instance.resolve_name(host)
+        TCPSocket.open(addr, port)
+        true
+      rescue => e
+        Logging::RLogger.instance.warn("You can't connect the #{ap} instance.")
+        nil
+      end
+
       def return_connection(ap, con)
         if select([con],nil,nil,0.0001)
           con.gets

--- a/lib/roma/messaging/con_pool.rb
+++ b/lib/roma/messaging/con_pool.rb
@@ -39,8 +39,7 @@ module Roma
         TCPSocket.open(addr, port)
         true
       rescue => e
-        Logging::RLogger.instance.warn("You can't connect the #{ap} instance.")
-        nil
+        false
       end
 
       def return_connection(ap, con)

--- a/lib/roma/romad.rb
+++ b/lib/roma/romad.rb
@@ -586,7 +586,9 @@ module Roma
     end
 
     def node_check(nid)
-      return false unless Roma::Messaging::ConPool.instance.check_connection(nid) 
+      if @startup && @rttable.enabled_failover == false
+       return false unless Roma::Messaging::ConPool.instance.check_connection(nid) 
+      end
       name = async_send_cmd(nid,"whoami\r\n",2)
       return false unless name
       if name != @stats.name

--- a/lib/roma/romad.rb
+++ b/lib/roma/romad.rb
@@ -587,7 +587,10 @@ module Roma
 
     def node_check(nid)
       if @startup && @rttable.enabled_failover == false
-       return false unless Roma::Messaging::ConPool.instance.check_connection(nid) 
+        unless Roma::Messaging::ConPool.instance.check_connection(nid) 
+          @log.info("I'm wating for booting the #{nid} instance.")
+          return false
+	end
       end
       name = async_send_cmd(nid,"whoami\r\n",2)
       return false unless name

--- a/lib/roma/romad.rb
+++ b/lib/roma/romad.rb
@@ -586,6 +586,7 @@ module Roma
     end
 
     def node_check(nid)
+      return false unless Roma::Messaging::ConPool.instance.check_connection(nid) 
       name = async_send_cmd(nid,"whoami\r\n",2)
       return false unless name
       if name != @stats.name


### PR DESCRIPTION
ROMA generates the ERROR in the log during booting ROMA. ROMA will research other instance at start, and the research method will create connection to this instance. BUT the instance is not yet so generate error.

I fixed this bug and it passed the test.