### PR TITLE
Update gemspec.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# Back-end storages
-group :tokyocabinet do
-  gem 'tokyocabinet', :git => 'https://github.com/roma/tokyocabinet-ruby.git'
-end

--- a/roma.gemspec
+++ b/roma.gemspec
@@ -5,14 +5,14 @@ require 'rake'
 require 'roma/version'
 
 Gem::Specification.new do |s|
-  s.authors = ["Junji Torii", "Hiroki Matsue"]
-  s.homepage = 'http://code.google.com/p/roma-prj/'
+  s.authors = ["Junji Torii", "Hiroki Matsue", "Hiroaki Iwase"]
+  s.homepage = 'http://roma-kvs.org/'
   s.name = "roma"
   s.version = Roma::VERSION
   s.license = 'GPL-3.0'
   s.summary = "ROMA server"
   s.description = <<-EOF
-    ROMA server
+    ROMA is one of the data storing systems for distributed key-value stores. It is a completely decentralized distributed system that consists of multiple processes, called nodes, on several machines. It is based on pure P2P architecture like a distributed hash table, thus it provides high availability and scalability.
   EOF
   s.files = FileList[
     '[A-Z]*',
@@ -24,8 +24,7 @@ Gem::Specification.new do |s|
     'examples/**/*',
   ]
 
-  # TODO: Specify Ruby version roma-1.1.0 must support
-  # s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 1.9.1'
 
   # Use these for libraries.
   s.require_path = 'lib'
@@ -40,14 +39,15 @@ Gem::Specification.new do |s|
   s.rdoc_options = [
                 '--line-numbers',
                 '--inline-source',
-                "--main", "README",
+                "--main", "README.md",
                 "-c UTF-8"
                ]
-  s.extra_rdoc_files = ["README", "CHANGELOG"]
+  s.extra_rdoc_files = ["README.md", "CHANGELOG"]
 
-  # TODO: for each gem, which version does rom depend on?
-  s.add_dependency 'eventmachine'
+  # TODO: for each gem, which version does roma depend on?
+  s.add_dependency 'eventmachine', '~> 1.0.0'
 
+  s.add_development_dependency 'tokyocabinet', '~> 1.29.1'
   s.add_development_dependency 'ffi'
   s.add_development_dependency 'gdbm'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
I updated `roma.gemspec`.
`tokyocabinet-1.29.1` gem include Ruby 1.9.2 supports, so we can use it from rubygem.org.