### PR TITLE
improve the connection behavior during booting

### DIFF
--- a/lib/roma/messaging/con_pool.rb
+++ b/lib/roma/messaging/con_pool.rb
@@ -34,12 +34,17 @@ module Roma
       end
 
       def check_connection(ap)
-        host, port = ap.split(/[:_]/)
-        addr = DNSCache.instance.resolve_name(host)
-        TCPSocket.open(addr, port)
+        unless @pool.key?(ap)
+          host, port = ap.split(/[:_]/)
+          addr = DNSCache.instance.resolve_name(host)
+          sock = TCPSocket.open(addr, port)
+          sock.close
+        end
         true
-      rescue => e
+      rescue Errno::ECONNREFUSED => e
         false
+      rescue => e
+        Logging::RLogger.instance.error("#{__FILE__}:#{__LINE__}:#{e}")
       end
 
       def return_connection(ap, con)

--- a/lib/roma/romad.rb
+++ b/lib/roma/romad.rb
@@ -596,7 +596,7 @@ module Roma
         unless Roma::Messaging::ConPool.instance.check_connection(nid) 
           @log.info("I'm wating for booting the #{nid} instance.")
           return false
-	end
+        end
       end
       name = async_send_cmd(nid,"whoami\r\n",2)
       return false unless name


### PR DESCRIPTION
I improved the connection behavior during booting. I close socket and use connection in the pool for checking other instance during booting.
Please check it.