### PR TITLE
remove unnecessary path in ssroute booting file

### DIFF
--- a/bin/ssroute
+++ b/bin/ssroute
@@ -4,7 +4,4 @@ require 'pathname'
 base_path = Pathname(__FILE__).dirname.parent.expand_path
 $LOAD_PATH.unshift("#{base_path}/lib")
 
-client_base_path = Pathname(__FILE__).dirname.parent.parent.expand_path
-$LOAD_PATH.unshift("#{client_base_path}/roma-ruby-client/lib")
-
 require 'roma/tools/ssroute'


### PR DESCRIPTION
When removing ruby/server directory, ssroute file contents was changed by mistake probably.
This tool don't require ruby-roma-client, but now it is not work without client.
So I remove relevant lines.