### PR TITLE
Fix unbalance number of vnodes after join a node. #46

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 ruby/server/wb_test/
 *.log*
 *.route*
+storage_test

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ ruby/server/wb_test/
 *.log*
 *.route*
 storage_test
+wb
+wb_test

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ Gemfile.lock
 ruby/server/wb_test/
 *.log*
 *.route*
-storage_test
+*storage_test
 wb
 wb_test
+localhost_*
+127.0.0.1_*

--- a/lib/roma/routing/random_partitioner.rb
+++ b/lib/roma/routing/random_partitioner.rb
@@ -1,24 +1,23 @@
 module Roma
   module Routing
     module RandomPartitioner
-
       def exclude_nodes(ap_str, rep_host)
-        exclude_nodes = self.nodes
+        exclude_nodes = nodes
         if rep_host
           exclude_nodes = [ap_str]
         else
           myhost = ap_str.split(/[:_]/)[0]
-          exclude_nodes.delete_if{|nid| nid.split(/[:_]/)[0] != myhost }
+          exclude_nodes.delete_if { |nid| nid.split(/[:_]/)[0] != myhost }
         end
         exclude_nodes
       end
 
-      def exclude_nodes_for_join(ap_str, rep_host)
+      def exclude_nodes_for_join(ap_str, _rep_host)
         [ap_str]
       end
 
-      alias :exclude_nodes_for_recover :exclude_nodes
-      alias :exclude_nodes_for_balance :exclude_nodes
+      alias_method :exclude_nodes_for_recover, :exclude_nodes
+      alias_method :exclude_nodes_for_balance, :exclude_nodes
 
       def myhost_include?(nodes, myhost)
         nodes.each do |nid|
@@ -29,7 +28,7 @@ module Roma
       private :myhost_include?
 
       # vnode sampling exclude +exclude_nodes+
-      def select_vn_for_join(exclude_nodes)
+      def select_vn_for_join(exclude_nodes, rep_host)
         short_idx = {}
         myhost_idx = {}
         idx = {}
@@ -61,15 +60,22 @@ module Roma
         ks = idx.keys
         vn = ks[rand(ks.length)]
         nids = idx[vn]
-        [vn, nids, rand(@rd.rn) == 0]
+
+        if !rep_host && nids[0].split(/[:_]/)[0] == myhost
+          is_primary = true
+        else
+          is_primary = rand(@rd.rn) == 0
+        end
+
+        [vn, nids, is_primary]
       end
 
       # select a vnodes where short of redundancy.
-      def select_vn_for_recover(exclude_nodes)
+      def select_vn_for_recover(exclude_nodes, _rep_host)
         ret = []
         @rd.v_idx.each_pair do |vn, nids|
-          if nids.length < @rd.rn && list_include?(nids,exclude_nodes) == false
-            ret << [vn,nids]
+          if nids.length < @rd.rn && list_include?(nids, exclude_nodes) == false
+            ret << [vn, nids]
           end
         end
         if ret.length == 0
@@ -81,27 +87,27 @@ module Roma
       end
 
       def select_node_for_release(ap_str, rep_host, nids)
-        buf = self.nodes
+        buf = nodes
 
         unless rep_host
           deny_hosts = []
-          nids.each{ |nid|
+          nids.each do |nid|
             host = nid.split(/[:_]/)[0]
             deny_hosts << host if host != ap_str.split(/[:_]/)[0]
-          }
-          buf.delete_if{|nid| deny_hosts.include?(nid.split(/[:_]/)[0])}
+          end
+          buf.delete_if { |nid| deny_hosts.include?(nid.split(/[:_]/)[0]) }
         else
-          nids.each{|nid| buf.delete(nid) }
+          nids.each { |nid| buf.delete(nid) }
         end
 
-        buf.delete_if{|instance| instance == ap_str}
+        buf.delete_if { |instance| instance == ap_str }
         to_nid = buf.sample
-        new_nids = nids.map{|n| n == ap_str ? to_nid : n }
+        new_nids = nids.map { |n| n == ap_str ? to_nid : n }
         [to_nid, new_nids]
       end
 
       # vnode sampling exclude +exclude_nodes+
-      def select_vn_for_balance(exclude_nodes)
+      def select_vn_for_balance(exclude_nodes, _rep_host)
         short_idx = {}
         idx = {}
         @rd.v_idx.each_pair do |vn, nids|
@@ -118,7 +124,6 @@ module Roma
         nids = idx[vn]
         [vn, nids, rand(@rd.rn) == 0]
       end
-
     end
   end
 end

--- a/test/roma-test-utils.rb
+++ b/test/roma-test-utils.rb
@@ -2,73 +2,172 @@ require 'shell'
 require 'pathname'
 require 'fileutils'
 require 'rbconfig'
+require 'open3'
 require 'roma/config'
 require 'roma/messaging/con_pool'
+require 'roma/logging/rlogger'
+require 'roma/client/rclient'
+require 'roma/client/client_pool'
+
+Roma::Client::RomaClient.class_eval do
+  def init_sync_routing_proc
+  end
+end
 
 module RomaTestUtils
+  DEFAULT_CONFIG = 'config4test.rb'
+  DEFAULT_HOST = 'localhost'
+  DEFAULT_IP = '127.0.0.1'
+  DEFAULT_PORTS = %w(11211 11212)
+  DEFAULT_NODES = DEFAULT_PORTS.map { |port| "#{DEFAULT_HOST}_#{port}" }
+  DEFAULT_TIMEOUT_SEC = 60
+
+  Roma::Logging::RLogger.create_singleton_instance("#{Roma::Config::LOG_PATH}/roma_test.log",
+                                                   Roma::Config::LOG_SHIFT_AGE,
+                                                   Roma::Config::LOG_SHIFT_SIZE)
+
   module_function
+
+  def start_roma(conf = DEFAULT_CONFIG, div_bits: 3, replication_in_host: true)
+    FileUtils.rm_rf(Dir.glob("#{Roma::Config::STORAGE_PATH}/#{DEFAULT_NODES[0][0..-2]}?*"))
+    FileUtils.rm_rf(Dir.glob("#{Roma::Config::STORAGE_PATH}/#{DEFAULT_IP}_#{DEFAULT_PORTS[0][0..-2]}?*"))
+    sleep 0.1
+
+    Open3.capture3("#{ruby_path} #{mkroute_path} #{DEFAULT_NODES.join(' ')} -d #{div_bits} --replication_in_host")
+    sleep 0.2
+
+    DEFAULT_NODES.each do |node|
+      do_command_romad(node, conf, replication_in_host)
+    end
+    sleep 1
+  end
+
+  def join_roma(node, conf = DEFAULT_CONFIG, replication_in_host: true)
+    do_command_romad(node, conf, replication_in_host, true)
+  end
+
+  def do_command_romad(node, conf, replication_in_host = true, is_join = false)
+    host, port = node.split('_')
+    romad_command = [
+      ruby_path, romad_path, host,
+      '-p', port,
+      '-d', '--verbose', '--disabled_cmd_protect',
+      '--config', "#{test_dir}/#{conf}"
+    ]
+    romad_command << '--replication_in_host' if replication_in_host
+    romad_command << "-j #{DEFAULT_NODES[0]}" if is_join
+
+    Open3.capture3(romad_command.join(' '))
+  end
+
+  def get_client
+    client_pool = Roma::Client::ClientPool.instance
+    client_pool.servers = DEFAULT_NODES
+    client_pool.client
+  end
+
+  def wait_join(node)
+    client = get_client
+    wait_count = 0
+    retry_count = 0
+    sleep 5
+
+    until client.rttable.nodes.include?(node)
+      sleep 1
+      client.update_rttable
+      wait_count += 1
+      fail "#{__method__} timeout" if wait_count > DEFAULT_TIMEOUT_SEC
+    end
+
+    while client.stats(node: node)['stats']['run_join'] == 'true'
+      sleep 1
+      wait_count += 1
+      fail "#{__method__} timeout" if wait_count > DEFAULT_TIMEOUT_SEC
+    end
+  end
+
+  def wait_failover(down_node)
+    client = get_client
+    stats_node = down_node == DEFAULT_NODES[0] ? DEFAULT_NODES[1] : DEFAULT_NODES[0]
+    wait_count = 0
+    sleep 1
+
+    while client.stats(node: stats_node)['routing']['nodes'] =~ /#{down_node}/
+      sleep 1
+      wait_count += 1
+      fail "#{__method__} timeout" if wait_count > DEFAULT_TIMEOUT_SEC
+    end
+  end
+
+  def wait_release(node)
+    client = get_client
+    wait_count = 0
+    sleep 1
+
+    while client.stats(node: node)['stats']['run_release'] == 'true'
+      sleep 1
+      wait_count += 1
+      fail "#{__method__} timeout" if wait_count > DEFAULT_TIMEOUT_SEC
+    end
+  end
+
+  def stop_roma
+    balse_message = %w(balse yes)
+    send_message(messages: balse_message)
+    Roma::Client::ConPool.instance.close_all
+    Roma::Messaging::ConPool.instance.close_all
+  end
+
+  def stop_roma_node(node)
+    send_message(messages: 'rbalse', node: node)
+    Roma::Client::ConPool.instance.close_all
+    Roma::Messaging::ConPool.instance.close_all
+  end
+
+  def release_roma_node(node)
+    send_message(messages: 'release', node: node)
+  end
+
+  private
+
   def base_dir
     Pathname(__FILE__).dirname.parent.expand_path
   end
 
   def bin_dir
-    base_dir + "bin"
+    base_dir + 'bin'
   end
 
   def test_dir
-    base_dir + "test"
+    base_dir + 'test'
   end
 
   def mkroute_path
-    (bin_dir + "mkroute").to_s
+    (bin_dir + 'mkroute').to_s
   end
 
   def romad_path
-    (bin_dir + "romad").to_s
+    (bin_dir + 'romad').to_s
   end
 
   def ruby_path
-    File.join(RbConfig::CONFIG["bindir"],
-              RbConfig::CONFIG["ruby_install_name"])
+    File.join(RbConfig::CONFIG['bindir'],
+              RbConfig::CONFIG['ruby_install_name'])
   end
 
-  def start_roma conf='config4test.rb'
-    sh = Shell.new
-    sh.transact do
-      Dir.glob("localhost_1121?.*").each{|f| rm f }
-    end
-    FileUtils.rm_rf("#{Roma::Config::STORAGE_PATH}/localhost_11211")
-    FileUtils.rm_rf("#{Roma::Config::STORAGE_PATH}/localhost_11212")
-    sleep 0.1
+  def send_message(messages: [], node: DEFAULT_NODES[0])
+    conn = Roma::Messaging::ConPool.instance.get_connection(node)
+    return false unless conn
 
-    sh.system(ruby_path, mkroute_path,
-              "localhost_11211","localhost_11212",
-              "-d","3",
-              "--replication_in_host")
-    sleep 0.2
-    do_command_romad conf
-    sleep 1
-  end
+    messages = [messages] if messages.class == String
 
-  def do_command_romad conf
-    sh = Shell.new
-    sh.system(ruby_path,romad_path,"localhost","-p","11211","-d","--verbose",
-              "--disabled_cmd_protect","--config","#{test_dir}/#{conf}")
-    sh.system(ruby_path,romad_path,"localhost","-p","11212","-d","--verbose",
-              "--disabled_cmd_protect","--config","#{test_dir}/#{conf}")
-  end
-
-  def stop_roma
-    conn = Roma::Messaging::ConPool.instance.get_connection("localhost_11211")
-    if conn
-      conn.write "balse\r\n"
+    messages.each do |message|
+      conn.write "#{message}\r\n"
       conn.gets
-      conn.write "yes\r\n"
-      conn.gets
-      conn.close
     end
-    Roma::Client::ConPool.instance.close_all
-  rescue =>e
-    puts "#{e} #{$@}"
+  rescue => e
+    puts "#{e} #{$ERROR_POSITION}"
+  ensure
+    Roma::Messaging::ConPool.instance.return_connection(node, conn)
   end
 end

--- a/test/t_cpdata.rb
+++ b/test/t_cpdata.rb
@@ -3,53 +3,51 @@
 require 'roma/client/rclient'
 require 'roma/messaging/con_pool'
 
+TCP_SERVER_PORT = 11_219
 $dat = {}
 
 def receive_command_server
-  $gs = TCPServer.open(11213)
-  while true
-    Thread.new($gs.accept){|s|
+  $gs = TCPServer.open(TCP_SERVER_PORT)
+  loop do
+    Thread.new($gs.accept) do |s|
       begin
-        loop {
-          res = s.gets
-          p res
-          if res==nil
-            s.close
-          elsif res.start_with?("pushv")
-            ss = res.split(" ")
+        while res = s.gets
+          if res.start_with?('pushv')
+            ss = res.split(' ')
             s.write("READY\r\n")
             len = s.gets.chomp
             $dat[ss[2].to_i] = receive_dump(s, len.to_i)
             s.write("STORED\r\n")
-          elsif res.start_with?("spushv")
-            ss = res.split(" ")
+          elsif res.start_with?('spushv')
+            ss = res.split(' ')
             s.write("READY\r\n")
             $dat[ss[2].to_i] = receive_stream_dump(s)
             s.write("STORED\r\n")
-          elsif res.start_with?("whoami")
+          elsif res.start_with?('whoami')
             s.write("ROMA\r\n")
-          elsif res.start_with?("rbalse")
+          elsif res.start_with?('rbalse')
             s.write("BYE\r\n")
-            s.close
             break
           else
             s.write("STORED\r\n")
           end
-        }
-      rescue =>e
+        end
+      rescue => e
         p e
-        p $@
+        p $ERROR_POSITION
+      ensure
+        s.close if s
       end
-    }
+    end
   end
-rescue =>e
+rescue => e
   p e
 end
 
 def receive_stream_dump(sok)
   ret = {}
   v = nil
-  loop {
+  loop do
     context_bin = sok.read(20)
     vn, last, clk, expt, klen = context_bin.unpack('NNNNN')
 
@@ -61,15 +59,15 @@ def receive_stream_dump(sok)
       v = sok.read(vlen)
     end
     ret[k] = [vn, last, clk, expt, v].pack('NNNNa*')
-  }
+  end
   ret
-rescue =>e
+rescue => e
   p e
 end
 
 def receive_dump(sok, len)
   dmp = ''
-  while(dmp.length != len.to_i)
+  while (dmp.length != len.to_i)
     dmp = dmp + sok.read(len.to_i - dmp.length)
   end
   sok.read(2)
@@ -78,7 +76,7 @@ def receive_dump(sok, len)
   else
     return nil
   end
-rescue =>e
+rescue => e
   false
 end
 
@@ -87,37 +85,37 @@ class CopyDataTest < Test::Unit::TestCase
   include RomaTestUtils
 
   def setup
-    @th = Thread.new{ receive_command_server }
+    @th = Thread.new { receive_command_server }
     start_roma
-    @rc=Roma::Client::RomaClient.new(["localhost_11211","localhost_11212"])
+    @rc = Roma::Client::RomaClient.new(%w(localhost_11211 localhost_11212))
   end
 
   def teardown
     stop_roma
     @th.kill
     $gs.close
-    Roma::Messaging::ConPool::instance.close_all
+    Roma::Messaging::ConPool.instance.close_all
   end
 
   def test_spushv
     # key wihch's vn = 0
     keys = []
     n = 1000
-    n.times{|i|
+    n.times do |i|
       d = Digest::SHA1.hexdigest(i.to_s).hex % @rc.rttable.hbits
       vn = @rc.rttable.get_vnode_id(d)
       if vn == 0
         keys << i.to_s
       end
-    }
+    end
     nid = @rc.rttable.search_nodes(0)
 
     push_a_vnode_stream('roma', 0, nid[0], keys)
 
-    keys.each{|k|
-      assert_equal( "#{k}-stream", @rc.get(k,true))
-#      puts "#{k} #{@rc.get(k)}"
-    }
+    keys.each do |k|
+      assert_equal("#{k}-stream", @rc.get(k, true))
+      #      puts "#{k} #{@rc.get(k)}"
+    end
   end
 
   def push_a_vnode_stream(hname, vn, nid, keys)
@@ -130,54 +128,53 @@ class CopyDataTest < Test::Unit::TestCase
       return res.chomp
     end
 
-    keys.each{|k|
-      v = k + "-stream"
+    keys.each do |k|
+      v = k + '-stream'
       data = [vn, Time.now.to_i, 1, 0x7fffffff, k.length, k, v.length, v].pack("NNNNNa#{k.length}Na#{v.length}")
       con.write(data)
-    }
-    con.write("\0"*20) # end of steram
+    end
+    con.write("\0" * 20) # end of steram
 
     res = con.gets # STORED\r\n or error string
-    Roma::Messaging::ConPool.instance.return_connection(nid,con)
+    Roma::Messaging::ConPool.instance.return_connection(nid, con)
     res.chomp! if res
     res
-  rescue =>e
+  rescue => e
     "#{e}"
   end
   private :push_a_vnode_stream
 
-
   def test_reqpushv
     make_dummy(1000)
 
-    dat=[]
-    dat[0] = reqpushv('roma',0)
-    assert_not_nil( dat[0] )
-    dat[0] = reqpushv('roma',0)
-    assert_not_nil( dat[0] )  # confirming twice access to same node
+    dat = []
+    dat[0] = reqpushv('roma', 0)
+    assert_not_nil(dat[0])
+    dat[0] = reqpushv('roma', 0)
+    assert_not_nil(dat[0])  # confirming twice access to same node
 
-    dat[1] = reqpushv('roma',536870912)
-    assert_not_nil( dat[1] )
-    dat[2] = reqpushv('roma',1073741824)
-    assert_not_nil( dat[2] )
-    dat[3] = reqpushv('roma',1610612736)
-    assert_not_nil( dat[3])
-    dat[4] = reqpushv('roma',2147483648)
-    assert_not_nil( dat[4] )
-    dat[5] = reqpushv('roma',2684354560)
-    assert_not_nil( dat[5] )
-    dat[6] = reqpushv('roma',3221225472,true)
-    assert_not_nil( dat[6] )
-    dat[7] = reqpushv('roma',3758096384,true)
-    assert_not_nil( dat[7] )
+    dat[1] = reqpushv('roma', 536_870_912)
+    assert_not_nil(dat[1])
+    dat[2] = reqpushv('roma', 1_073_741_824)
+    assert_not_nil(dat[2])
+    dat[3] = reqpushv('roma', 1_610_612_736)
+    assert_not_nil(dat[3])
+    dat[4] = reqpushv('roma', 2_147_483_648)
+    assert_not_nil(dat[4])
+    dat[5] = reqpushv('roma', 2_684_354_560)
+    assert_not_nil(dat[5])
+    dat[6] = reqpushv('roma', 3_221_225_472, true)
+    assert_not_nil(dat[6])
+    dat[7] = reqpushv('roma', 3_758_096_384, true)
+    assert_not_nil(dat[7])
 
     a = 0
-    dat.each{|v| a+=v.length }
-    assert_equal( 1000,a )
+    dat.each { |v| a += v.length }
+    assert_equal(1000, a)
   end
 
   def wait(vn)
-    while $dat.key?(vn) do
+    while $dat.key?(vn)
       sleep 0.01
     end
     $dat[vn]
@@ -185,38 +182,38 @@ class CopyDataTest < Test::Unit::TestCase
 
   # set dummy data of n count
   def make_dummy(n)
-    n.times{|i|
-      assert( @rc.set(i.to_s,i.to_s)=="STORED" )
-    }
+    n.times do |i|
+      assert(@rc.set(i.to_s, i.to_s) == 'STORED')
+    end
   end
 
-  def reqpushv(hname,vn,is_primary=false)
+  def reqpushv(_hname, vn, is_primary = false)
     $dat.delete(vn)
-    con = Roma::Messaging::ConPool.instance.get_connection("localhost_11211")
+    con = Roma::Messaging::ConPool.instance.get_connection('localhost_11211')
     res = nil
-    10.times{
-      con.write("reqpushv #{vn} localhost_11213 #{is_primary}\r\n")
+    10.times do
+      con.write("reqpushv #{vn} localhost_#{TCP_SERVER_PORT} #{is_primary}\r\n")
       res = con.gets
       break if res == "PUSHED\r\n"
       sleep 0.5
-    }
-    assert_equal( "PUSHED\r\n", res )
+    end
+    assert_equal("PUSHED\r\n", res)
     con.close
 
-    until $dat.key?(vn) do
+    until $dat.key?(vn)
       Thread.pass
       sleep 0.01
     end
     $dat[vn]
-  rescue =>e
+  rescue => e
     p e
-    p $@
+    p $ERROR_POSITION
     return nil
   end
 
   def receive_dump(sok, len)
     dmp = ''
-    while(dmp.length != len.to_i)
+    while (dmp.length != len.to_i)
       dmp = dmp + sok.read(len.to_i - dmp.length)
     end
     sok.read(2)
@@ -225,9 +222,8 @@ class CopyDataTest < Test::Unit::TestCase
     else
       return nil
     end
-  rescue =>e
-    @log.error("#{e}\n#{$@}")
+  rescue => e
+    @log.error("#{e}\n#{$ERROR_POSITION}")
     false
   end
-
 end

--- a/test/t_routing_logic.rb
+++ b/test/t_routing_logic.rb
@@ -1,0 +1,120 @@
+#!/usr/bin/env ruby
+
+class RoutingLogicTest < Test::Unit::TestCase
+  include RomaTestUtils
+
+  NEW_PORTS = %w(11213 11214)
+
+  def teardown
+    stop_roma
+  rescue => e
+    puts "#{e} #{$ERROR_POSITION}"
+  end
+
+  data(
+  'single_host' => [
+    true,
+    NEW_PORTS.map { |port| "#{DEFAULT_HOST}_#{port}" }],
+  'multiple_hosts' => [
+    false,
+    NEW_PORTS.map { |port| "#{DEFAULT_IP}_#{port}" }],
+  'multiple_hosts_include_some_hosts' => [
+    false,
+    ["#{DEFAULT_IP}_#{NEW_PORTS[0]}", "#{DEFAULT_HOST}_#{NEW_PORTS[1]}"]]
+  )
+  def test_join(data)
+    replication_in_host, new_nodes = data
+    start_roma(div_bits: 5, replication_in_host: replication_in_host)
+    sleep 12 # Wait cluster starting, otherwise join will never finish
+    client = get_client
+
+    # Join nodes
+    assert_equal(DEFAULT_NODES.size, client.rttable.nodes.size)
+    new_nodes.each do |new_node|
+      join_roma(new_node, replication_in_host: replication_in_host)
+      wait_join(new_node)
+      stats = client.stats(node: new_node)
+      assert_match(/#{new_node}/, stats['routing']['nodes'])
+      assert_not_equal(0, stats['routing']['secondary'].to_i)
+    end
+
+    new_node = new_nodes.last
+
+    # Release and stop a node
+    release_roma_node(new_node)
+    wait_release(new_node)
+    stop_roma_node(new_node)
+    wait_failover(new_node)
+    stats = client.stats
+    assert_no_match(/#{new_node}/, stats['routing']['nodes'])
+    assert_equal(0, stats['routing']['short_vnodes'].to_i)
+
+    # Join a node without short vnodes
+    join_roma(new_node, replication_in_host: replication_in_host)
+    wait_join(new_node)
+    stats = client.stats(node: new_node)
+    assert_match(/#{new_node}/, stats['routing']['nodes'])
+    assert_not_equal(0, stats['routing']['secondary'].to_i)
+
+    # Stop a node and generate short vnodes
+    stop_roma_node(new_node)
+    wait_failover(new_node)
+    stats = client.stats
+    assert_no_match(/#{new_node}/, stats['routing']['nodes'])
+    assert_not_equal(0, stats['routing']['short_vnodes'].to_i)
+
+    # Join a node with short vnodes
+    join_roma(new_node, replication_in_host: replication_in_host)
+    wait_join(new_node)
+    stats = client.stats(node: new_node)
+    assert_match(/#{new_node}/, stats['routing']['nodes'])
+    assert_not_equal(0, stats['routing']['secondary'].to_i)
+  end
+
+  def test_join_when_num_of_hosts_changing
+    replication_in_host = false
+    same_host_node = "#{DEFAULT_HOST}_#{NEW_PORTS[0]}"
+    other_host_node = "#{DEFAULT_IP}_#{NEW_PORTS[1]}"
+
+    start_roma(div_bits: 5, replication_in_host: replication_in_host)
+    sleep 12 # Wait cluster starting, otherwise join will never finish
+    client = get_client
+
+    # Join other_host_node
+    join_roma(other_host_node, replication_in_host: replication_in_host)
+    wait_join(other_host_node)
+    stats = client.stats(node: other_host_node)
+    assert_match(/#{other_host_node}/, stats['routing']['nodes'])
+    assert_not_equal(0, stats['routing']['secondary'].to_i)
+
+    # Stop other_host_node and generate short vnodes
+    stop_roma_node(other_host_node)
+    wait_failover(other_host_node)
+    stats = client.stats
+    assert_no_match(/#{other_host_node}/, stats['routing']['nodes'])
+    assert_not_equal(0, stats['routing']['short_vnodes'].to_i)
+
+    # Join other_host_node
+    join_roma(other_host_node, replication_in_host: replication_in_host)
+    wait_join(other_host_node)
+    stats = client.stats(node: other_host_node)
+    assert_match(/#{other_host_node}/, stats['routing']['nodes'])
+    assert_not_equal(0, stats['routing']['secondary'].to_i)
+
+    # Stop other_host_node and generate short vnodes
+    stop_roma_node(other_host_node)
+    wait_failover(other_host_node)
+    stats = client.stats
+    assert_no_match(/#{other_host_node}/, stats['routing']['nodes'])
+    assert_not_equal(0, stats['routing']['short_vnodes'].to_i)
+
+    # Join same_host_node (secondary will be 0 in this case)
+    join_roma(same_host_node, replication_in_host: replication_in_host)
+    wait_join(same_host_node)
+    stats = client.stats(node: same_host_node)
+    assert_match(/#{same_host_node}/, stats['routing']['nodes'])
+    assert_equal(0, stats['routing']['secondary'].to_i)
+  end
+
+  # TODO: recover, balance command tests
+end

--- a/test/t_routing_logic.rb
+++ b/test/t_routing_logic.rb
@@ -24,7 +24,7 @@ class RoutingLogicTest < Test::Unit::TestCase
   )
   def test_join(data)
     replication_in_host, new_nodes = data
-    start_roma(div_bits: 5, replication_in_host: replication_in_host)
+    start_roma(div_bits: 6, replication_in_host: replication_in_host)
     sleep 12 # Wait cluster starting, otherwise join will never finish
     client = get_client
 
@@ -34,8 +34,8 @@ class RoutingLogicTest < Test::Unit::TestCase
       join_roma(new_node, replication_in_host: replication_in_host)
       wait_join(new_node)
       stats = client.stats(node: new_node)
-      assert_match(/#{new_node}/, stats['routing']['nodes'])
-      assert_not_equal(0, stats['routing']['secondary'].to_i)
+      assert_match(/#{new_node}/, stats['routing.nodes'])
+      assert_not_equal(0, stats['routing.secondary'].to_i)
     end
 
     new_node = new_nodes.last
@@ -46,29 +46,29 @@ class RoutingLogicTest < Test::Unit::TestCase
     stop_roma_node(new_node)
     wait_failover(new_node)
     stats = client.stats
-    assert_no_match(/#{new_node}/, stats['routing']['nodes'])
-    assert_equal(0, stats['routing']['short_vnodes'].to_i)
+    assert_no_match(/#{new_node}/, stats['routing.nodes'])
+    assert_equal(0, stats['routing.short_vnodes'].to_i)
 
     # Join a node without short vnodes
     join_roma(new_node, replication_in_host: replication_in_host)
     wait_join(new_node)
     stats = client.stats(node: new_node)
-    assert_match(/#{new_node}/, stats['routing']['nodes'])
-    assert_not_equal(0, stats['routing']['secondary'].to_i)
+    assert_match(/#{new_node}/, stats['routing.nodes'])
+    assert_not_equal(0, stats['routing.secondary'].to_i)
 
     # Stop a node and generate short vnodes
     stop_roma_node(new_node)
     wait_failover(new_node)
     stats = client.stats
-    assert_no_match(/#{new_node}/, stats['routing']['nodes'])
-    assert_not_equal(0, stats['routing']['short_vnodes'].to_i)
+    assert_no_match(/#{new_node}/, stats['routing.nodes'])
+    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
 
     # Join a node with short vnodes
     join_roma(new_node, replication_in_host: replication_in_host)
     wait_join(new_node)
     stats = client.stats(node: new_node)
-    assert_match(/#{new_node}/, stats['routing']['nodes'])
-    assert_not_equal(0, stats['routing']['secondary'].to_i)
+    assert_match(/#{new_node}/, stats['routing.nodes'])
+    assert_not_equal(0, stats['routing.secondary'].to_i)
   end
 
   def test_join_when_num_of_hosts_changing
@@ -76,7 +76,7 @@ class RoutingLogicTest < Test::Unit::TestCase
     same_host_node = "#{DEFAULT_HOST}_#{NEW_PORTS[0]}"
     other_host_node = "#{DEFAULT_IP}_#{NEW_PORTS[1]}"
 
-    start_roma(div_bits: 5, replication_in_host: replication_in_host)
+    start_roma(div_bits: 6, replication_in_host: replication_in_host)
     sleep 12 # Wait cluster starting, otherwise join will never finish
     client = get_client
 
@@ -84,36 +84,36 @@ class RoutingLogicTest < Test::Unit::TestCase
     join_roma(other_host_node, replication_in_host: replication_in_host)
     wait_join(other_host_node)
     stats = client.stats(node: other_host_node)
-    assert_match(/#{other_host_node}/, stats['routing']['nodes'])
-    assert_not_equal(0, stats['routing']['secondary'].to_i)
+    assert_match(/#{other_host_node}/, stats['routing.nodes'])
+    assert_not_equal(0, stats['routing.secondary'].to_i)
 
     # Stop other_host_node and generate short vnodes
     stop_roma_node(other_host_node)
     wait_failover(other_host_node)
     stats = client.stats
-    assert_no_match(/#{other_host_node}/, stats['routing']['nodes'])
-    assert_not_equal(0, stats['routing']['short_vnodes'].to_i)
+    assert_no_match(/#{other_host_node}/, stats['routing.nodes'])
+    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
 
     # Join other_host_node
     join_roma(other_host_node, replication_in_host: replication_in_host)
     wait_join(other_host_node)
     stats = client.stats(node: other_host_node)
-    assert_match(/#{other_host_node}/, stats['routing']['nodes'])
-    assert_not_equal(0, stats['routing']['secondary'].to_i)
+    assert_match(/#{other_host_node}/, stats['routing.nodes'])
+    assert_not_equal(0, stats['routing.secondary'].to_i)
 
     # Stop other_host_node and generate short vnodes
     stop_roma_node(other_host_node)
     wait_failover(other_host_node)
     stats = client.stats
-    assert_no_match(/#{other_host_node}/, stats['routing']['nodes'])
-    assert_not_equal(0, stats['routing']['short_vnodes'].to_i)
+    assert_no_match(/#{other_host_node}/, stats['routing.nodes'])
+    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
 
     # Join same_host_node (secondary will be 0 in this case)
     join_roma(same_host_node, replication_in_host: replication_in_host)
     wait_join(same_host_node)
     stats = client.stats(node: same_host_node)
-    assert_match(/#{same_host_node}/, stats['routing']['nodes'])
-    assert_equal(0, stats['routing']['secondary'].to_i)
+    assert_match(/#{same_host_node}/, stats['routing.nodes'])
+    assert_equal(0, stats['routing.secondary'].to_i)
   end
 
   # TODO: recover, balance command tests

--- a/test/t_writebehind.rb
+++ b/test/t_writebehind.rb
@@ -8,49 +8,48 @@ require 'roma/client/plugin/alist'
 require 'roma/client/plugin/map'
 
 module FileWriterTests
-
   # making and writing test
   def test_wb_write
     system('rm -rf wb_test')
-    fw = Roma::WriteBehind::FileWriter.new("wb_test", 1024 * 1024, Logger.new(nil))
+    fw = Roma::WriteBehind::FileWriter.new('wb_test', 1024 * 1024, Logger.new(nil))
     path = "wb_test/roma0_11211/roma/#{Time.now.strftime('%Y%m%d')}/"
 
     assert(!File.exist?("#{path}/0.wb"))
-    100.times{|i|
-      fw.write('roma',i,"key-#{i}","val-#{i}")
-    }
+    100.times do |i|
+      fw.write('roma', i, "key-#{i}", "val-#{i}")
+    end
     assert(File.exist?("#{path}/0.wb"))
     assert(!File.exist?("#{path}/1.wb"))
 
     fw.rotate('roma')
 
     i = 100
-    fw.write('roma',i,"key-#{i}","val-#{i}")
+    fw.write('roma', i, "key-#{i}", "val-#{i}")
     assert(File.exist?("#{path}/1.wb"))
 
     fw.close_all
 
     wb0 = read_wb("#{path}/0.wb")
-    assert_equal(100,wb0.length )
-    wb0.each{|last, cmd, key, val|
-      assert_equal( "key-#{cmd}",key)
-      assert_equal( "val-#{cmd}",val)
-    }
+    assert_equal(100, wb0.length)
+    wb0.each do |_last, cmd, key, val|
+      assert_equal("key-#{cmd}", key)
+      assert_equal("val-#{cmd}", val)
+    end
     wb1 = read_wb("#{path}/1.wb")
-    assert_equal(1,wb1.length )
+    assert_equal(1, wb1.length)
   end
 
   # rotation test per data
   def test_wb_rotation
     system('rm -rf wb_test')
-    fw = Roma::WriteBehind::FileWriter.new("wb_test", 900, Logger.new(nil))
+    fw = Roma::WriteBehind::FileWriter.new('wb_test', 900, Logger.new(nil))
     path = "wb_test/roma0_11211/roma/#{Time.now.strftime('%Y%m%d')}/"
 
-    100.times{|i|
-      fw.write('roma',0,
-               sprintf("key-%04d",i),
-               sprintf("val-%04d",i))
-    }
+    100.times do |i|
+      fw.write('roma', 0,
+               sprintf('key-%04d', i),
+               sprintf('val-%04d', i))
+    end
 
     assert(File.exist?("#{path}/0.wb"))
     assert(File.exist?("#{path}/1.wb"))
@@ -62,60 +61,60 @@ module FileWriterTests
   # rotation test per time
   def test_rotation2
     system('rm -rf wb_test')
-    fw = Roma::WriteBehind::FileWriter.new("wb_test", 1024 * 1024, Logger.new(nil))
+    fw = Roma::WriteBehind::FileWriter.new('wb_test', 1024 * 1024, Logger.new(nil))
     path = "wb_test/roma0_11211/roma/#{Time.now.strftime('%Y%m%d')}/"
 
     # rottime's usec have some value,from instance was created
-    rt = fw.instance_eval{ @rottime }
-    assert_not_equal(0, rt.hour + rt.min + rt.sec+ rt.usec)
+    rt = fw.instance_eval { @rottime }
+    assert_not_equal(0, rt.hour + rt.min + rt.sec + rt.usec)
     # formatting execute in today's date
     assert_equal(Time.now.day, rt.day)
     # confirming the file do not exist
     assert(!File.exist?("#{path}/0.wb"))
-    fw.write('roma',1,"key","val")
+    fw.write('roma', 1, 'key', 'val')
     # Open when somenthing to write,and in same timing rottime is updated
-    rt = fw.instance_eval{ @rottime }
+    rt = fw.instance_eval { @rottime }
     # In this time, under of date become "0"
-    assert_equal(0, rt.hour + rt.min + rt.sec+ rt.usec)
+    assert_equal(0, rt.hour + rt.min + rt.sec + rt.usec)
     # date become tomorrow
     assert_not_equal(Time.now.day, rt.day)
-    10.times{|i|
-      fw.write('roma',i,"key-#{i}","val-#{i}")
-    }
+    10.times do |i|
+      fw.write('roma', i, "key-#{i}", "val-#{i}")
+    end
     # confirming file is only 1 not over 2
     assert(File.exist?("#{path}/0.wb"))
     assert(!File.exist?("#{path}/1.wb"))
 
     # set rottime to now forcibly
-    fw.instance_eval{ @rottime=Time.now }
+    fw.instance_eval { @rottime = Time.now }
     # confriming to change rottime
-    assert_not_equal(rt, fw.instance_eval{ @rottime })
+    assert_not_equal(rt, fw.instance_eval { @rottime })
     # When something write, rotation is occured
-    fw.write('roma',1,"key","val")
+    fw.write('roma', 1, 'key', 'val')
     assert(File.exist?("#{path}/1.wb"))
     # rottime turn back because of test shold not step over the day.
-    assert_equal(rt, fw.instance_eval{ @rottime })
+    assert_equal(rt, fw.instance_eval { @rottime })
   end
 
   # rotation test from outside
   def test_wb_rotation3
     system('rm -rf wb_test')
-    fw = Roma::WriteBehind::FileWriter.new("wb_test", 1024 * 1024, Logger.new(nil))
+    fw = Roma::WriteBehind::FileWriter.new('wb_test', 1024 * 1024, Logger.new(nil))
     path = "wb_test/roma0_11211/roma/#{Time.now.strftime('%Y%m%d')}/"
 
     # confirming file don't exist
     assert(!File.exist?("#{path}/0.wb"))
-    10.times{|i|
-      fw.write('roma',i,"key-#{i}","val-#{i}")
-    }
+    10.times do |i|
+      fw.write('roma', i, "key-#{i}", "val-#{i}")
+    end
     # confirming file is only 1 not over 2
     assert(File.exist?("#{path}/0.wb"))
     assert(!File.exist?("#{path}/1.wb"))
 
     fw.rotate('roma')
-    10.times{|i|
-      fw.write('roma',i,"key-#{i}","val-#{i}")
-    }
+    10.times do |i|
+      fw.write('roma', i, "key-#{i}", "val-#{i}")
+    end
     # confirming files are 2 not over 3
     assert(File.exist?("#{path}/0.wb"))
     assert(File.exist?("#{path}/1.wb"))
@@ -129,9 +128,9 @@ module FileWriterTests
     assert(File.exist?("#{path}/0.wb"))
     assert(File.exist?("#{path}/1.wb"))
     assert(!File.exist?("#{path}/2.wb"))
-    10.times{|i|
-      fw.write('roma',i,"key-#{i}","val-#{i}")
-    }
+    10.times do |i|
+      fw.write('roma', i, "key-#{i}", "val-#{i}")
+    end
     # confirming files are 3 not over 4
     assert(File.exist?("#{path}/0.wb"))
     assert(File.exist?("#{path}/1.wb"))
@@ -139,48 +138,46 @@ module FileWriterTests
     assert(!File.exist?("#{path}/3.wb"))
   end
 
-
   def test_wb_get_current_file_path
     system('rm -rf wb_test')
-    fw = Roma::WriteBehind::FileWriter.new("wb_test", 900, Logger.new(nil))
+    fw = Roma::WriteBehind::FileWriter.new('wb_test', 900, Logger.new(nil))
 
-    assert_nil( fw.get_current_file_path('roma') )
+    assert_nil(fw.get_current_file_path('roma'))
 
-    fw.write('roma',0,"key","val")
+    fw.write('roma', 0, 'key', 'val')
 
     path = File.expand_path("./wb_test/roma0_11211/roma/#{Time.now.strftime('%Y%m%d')}/")
-    assert_equal(  File.join(path,"0.wb"), fw.get_current_file_path('roma'))
+    assert_equal(File.join(path, '0.wb'), fw.get_current_file_path('roma'))
 
     fw.rotate('roma')
-    assert_nil( fw.get_current_file_path('roma'))
+    assert_nil(fw.get_current_file_path('roma'))
 
-    fw.write('roma',0,"key","val")
-    assert_equal( File.join(path,"1.wb"), fw.get_current_file_path('roma') )
+    fw.write('roma', 0, 'key', 'val')
+    assert_equal(File.join(path, '1.wb'), fw.get_current_file_path('roma'))
   end
 
   def test_wb_get_path
     system('rm -rf wb_test')
-    fw = Roma::WriteBehind::FileWriter.new("wb_test", 900, Logger.new(nil))
-    path = File.expand_path("./wb_test/roma0_11211/roma")
-    assert_equal( path, fw.wb_get_path('roma'))
+    fw = Roma::WriteBehind::FileWriter.new('wb_test', 900, Logger.new(nil))
+    path = File.expand_path('./wb_test/roma0_11211/roma')
+    assert_equal(path, fw.wb_get_path('roma'))
   end
 
   def read_wb(fname)
     ret = []
-    open(fname,'rb'){|f|
-      until(f.eof?)
+    open(fname, 'rb') do |f|
+      until f.eof?
         b1 = f.read(10)
         last, cmd, klen = b1.unpack('NnN')
         key = f.read(klen)
         b2 = f.read(4)
         vlen = b2.unpack('N')[0]
         val = f.read(vlen)
-        ret << [last,cmd,key,val]
+        ret << [last, cmd, key, val]
       end
-    }
+    end
     ret
   end
-
 end
 
 class FileWriterTest < Test::Unit::TestCase
@@ -189,7 +186,7 @@ class FileWriterTest < Test::Unit::TestCase
   def setup
     @stats = Roma::Stats.instance
     @stats.address = 'roma0'
-    @stats.port = 11211
+    @stats.port = 11_211
   end
 
   def teardown
@@ -203,89 +200,87 @@ class WriteBehindTest < Test::Unit::TestCase
 
   def setup
     start_roma
-    @rc=Roma::Client::RomaClient.new(["localhost_11211","localhost_11212"],
-                                     [Roma::Client::Plugin::Alist,
-                                      Roma::Client::Plugin::Map])
+    @rc = Roma::Client::RomaClient.new(%w(localhost_11211 localhost_11212),
+                                       [Roma::Client::Plugin::Alist,
+                                        Roma::Client::Plugin::Map])
     system('rm -rf wb')
   end
 
   def teardown
     stop_roma
-    Roma::Messaging::ConPool::instance.close_all
+    Roma::Messaging::ConPool.instance.close_all
    rescue => e
-    puts "#{e} #{$@}"
+     puts "#{e} #{$ERROR_POSITION}"
   end
 
   def test_wb2_stat
-    ret = send_cmd("localhost_11211", "stat wb_command_map")
+    ret = send_cmd('localhost_11211', 'stat wb_command_map')
     assert_equal("stats.wb_command_map {}\r\n", ret)
   end
 
   def test_wb2_command_map
-    send_cmd("localhost_11211", "wb_command_map {:set=>1}")
-    ret = send_cmd("localhost_11211", "stat wb_command_map")
+    send_cmd('localhost_11211', 'wb_command_map {:set=>1}')
+    ret = send_cmd('localhost_11211', 'stat wb_command_map')
     assert_equal("stats.wb_command_map {:set=>1}\r\n", ret)
   end
 
   def test_wb2_set
-    send_cmd("localhost_11211", "wb_command_map {:set=>1}")
-    assert_equal("STORED", @rc.set("abc","value abc",0,true))
-    send_cmd("localhost_11211", "writebehind_rotate roma")
+    send_cmd('localhost_11211', 'wb_command_map {:set=>1}')
+    assert_equal('STORED', @rc.set('abc', 'value abc', 0, true))
+    send_cmd('localhost_11211', 'writebehind_rotate roma')
 
     wb0 = read_wb("#{wb_path}/0.wb")
     assert_equal(1, wb0.length)
-    wb0.each do |last, cmd, key, val|
-      puts "#{cmd} #{key} #{val.inspect}"
+    wb0.each do |_last, cmd, key, val|
+      # puts "#{cmd} #{key} #{val.inspect}"
       assert_equal(1, cmd)
-      assert_equal("abc", key)
-      assert_equal("value abc", val)
+      assert_equal('abc', key)
+      assert_equal('value abc', val)
     end
   end
 
   def test_wb2_set2
-    send_cmd("localhost_11211", "wb_command_map {:set=>1, :set__prev=>2}")
-    assert_equal("STORED", @rc.set("abc","val1",0,true))
-    assert_equal("STORED", @rc.set("abc","val2",0,true))
-    send_cmd("localhost_11211", "writebehind_rotate roma")
+    send_cmd('localhost_11211', 'wb_command_map {:set=>1, :set__prev=>2}')
+    assert_equal('STORED', @rc.set('abc', 'val1', 0, true))
+    assert_equal('STORED', @rc.set('abc', 'val2', 0, true))
+    send_cmd('localhost_11211', 'writebehind_rotate roma')
 
-    res = [[1,"abc","val1"], [2,"abc","val1"], [1,"abc","val2"]]
+    res = [[1, 'abc', 'val1'], [2, 'abc', 'val1'], [1, 'abc', 'val2']]
     wb0 = read_wb("#{wb_path}/0.wb")
     assert_equal(3, wb0.length)
     i = 0
-    wb0.each do |last, cmd, key, val|
+    wb0.each do |_last, cmd, key, val|
       # puts "#{cmd} #{key} #{val.inspect} #{i}"
       assert_equal(res[i][0], cmd)
       assert_equal(res[i][1], key)
       assert_equal(res[i][2], val)
-      i+=1
+      i += 1
     end
   end
 
-
   def test_wb2_storage_commands
-    h = {:set=>1,:delete=>2,:add=>3,:replace=>4,:append=>5,:prepend=>6,:cas=>7,:incr=>8,:decr=>9,:set_expt=>10}
-    send_cmd("localhost_11211", "wb_command_map #{h}")
-    assert_equal("STORED", @rc.set("abc","1",0,true))
-    assert_equal("DELETED", @rc.delete("abc"))
-    assert_equal("STORED", @rc.add("abc","1",0,true))
-    assert_equal("STORED", @rc.replace("abc","2",0,true))
-    assert_equal("STORED", @rc.append("abc","3"))
-    assert_equal("STORED", @rc.prepend("abc","1"))
-    res = @rc.cas("abc", 0, true) do |v|
-      v = "128"
+    h = { set: 1, delete: 2, add: 3, replace: 4, append: 5, prepend: 6, cas: 7, incr: 8, decr: 9, set_expt: 10 }
+    send_cmd('localhost_11211', "wb_command_map #{h}")
+    assert_equal('STORED', @rc.set('abc', '1', 0, true))
+    assert_equal('DELETED', @rc.delete('abc'))
+    assert_equal('STORED', @rc.add('abc', '1', 0, true))
+    assert_equal('STORED', @rc.replace('abc', '2', 0, true))
+    assert_equal('STORED', @rc.append('abc', '3'))
+    assert_equal('STORED', @rc.prepend('abc', '1'))
+    res = @rc.cas('abc', 0, true) do |_v|
+      v = '128'
     end
-    assert_equal("STORED", res)
-    assert_equal(129, @rc.incr("abc"))
-    assert_equal(128, @rc.decr("abc"))
-    res = send_cmd("localhost_11211", "set_expt abc 100")
-    assert_equal("STORED", res.chomp)
-    send_cmd("localhost_11211", "writebehind_rotate roma")
+    assert_equal('STORED', res)
+    assert_equal(129, @rc.incr('abc'))
+    assert_equal(128, @rc.decr('abc'))
+    res = send_cmd('localhost_11211', 'set_expt abc 100')
+    assert_equal('STORED', res.chomp)
+    send_cmd('localhost_11211', 'writebehind_rotate roma')
 
-
-    res = {1=>'1',2=>'1',3=>'1',4=>'2',5=>'23',6=>'123',7=>'128',8=>'129',9=>'128', 10=>nil}
+    res = { 1 => '1', 2 => '1', 3 => '1', 4 => '2', 5 => '23', 6 => '123', 7 => '128', 8 => '129', 9 => '128', 10 => nil }
     wb0 = read_wb("#{wb_path}/0.wb")
     assert_equal(10, wb0.length)
-    wb0.each do |last, cmd, key, val|
+    wb0.each do |_last, cmd, _key, val|
       # puts "#{cmd} #{key} #{val.inspect}"
       assert_equal(res[cmd], val) if res[cmd]
     end
@@ -293,52 +288,52 @@ class WriteBehindTest < Test::Unit::TestCase
 
   def test_wb2_storage_commands2
     h = {
-      :set=>1, :set__prev=>11,
-      :delete=>2, :delete__prev=>12,
-      :add=>3, :add__prev=>13,
-      :replace=>4, :replace__prev=>14,
-      :append=>5,:append__prev=>15,
-      :prepend=>6,:prepend__prev=>16,
-      :cas=>7,:cas__prev=>17,
-      :incr=>8,:incr__prev=>18,
-      :decr=>9,:decr__prev=>19,
-      :set_expt=>10,:set_expt__prev=>20
+      set: 1, set__prev: 11,
+      delete: 2, delete__prev: 12,
+      add: 3, add__prev: 13,
+      replace: 4, replace__prev: 14,
+      append: 5, append__prev: 15,
+      prepend: 6, prepend__prev: 16,
+      cas: 7, cas__prev: 17,
+      incr: 8, incr__prev: 18,
+      decr: 9, decr__prev: 19,
+      set_expt: 10, set_expt__prev: 20
     }
-    send_cmd("localhost_11211", "wb_command_map #{h}")
-    assert_equal("STORED", @rc.set("abc","1",0,true))
-    assert_equal("DELETED", @rc.delete("abc"))
-    assert_equal("STORED", @rc.add("abc","1",0,true))
-    assert_equal("STORED", @rc.replace("abc","2",0,true))
-    assert_equal("STORED", @rc.append("abc","3"))
-    assert_equal("STORED", @rc.prepend("abc","1"))
-    res = @rc.cas("abc", 0, true) do |v|
-      v = "128"
+    send_cmd('localhost_11211', "wb_command_map #{h}")
+    assert_equal('STORED', @rc.set('abc', '1', 0, true))
+    assert_equal('DELETED', @rc.delete('abc'))
+    assert_equal('STORED', @rc.add('abc', '1', 0, true))
+    assert_equal('STORED', @rc.replace('abc', '2', 0, true))
+    assert_equal('STORED', @rc.append('abc', '3'))
+    assert_equal('STORED', @rc.prepend('abc', '1'))
+    res = @rc.cas('abc', 0, true) do |_v|
+      v = '128'
     end
-    assert_equal("STORED", res)
-    assert_equal(129, @rc.incr("abc"))
-    assert_equal(128, @rc.decr("abc"))
-    res = send_cmd("localhost_11211", "set_expt abc 100")
-    assert_equal("STORED", res.chomp)
+    assert_equal('STORED', res)
+    assert_equal(129, @rc.incr('abc'))
+    assert_equal(128, @rc.decr('abc'))
+    res = send_cmd('localhost_11211', 'set_expt abc 100')
+    assert_equal('STORED', res.chomp)
 
-    send_cmd("localhost_11211", "writebehind_rotate roma")
+    send_cmd('localhost_11211', 'writebehind_rotate roma')
 
     res = [
-           [1, "abc", "1"], [12, "abc", "1"],
-           [2, "abc", "1"],
-           [3, "abc", "1"], [14, "abc", "1"],
-           [4, "abc", "2"], [15, "abc", "2"],
-           [5, "abc", "23"],[16, "abc", "23"],
-           [6, "abc", "123"], [17, "abc", "123"],
-           [7, "abc", "128"], [18, "abc", "128"],
-           [8, "abc", "129"], [19, "abc", "129"],
-           [9, "abc", "128"],
-           [20, "abc"], [10, "abc"]
-          ]
+      [1, 'abc', '1'], [12, 'abc', '1'],
+      [2, 'abc', '1'],
+      [3, 'abc', '1'], [14, 'abc', '1'],
+      [4, 'abc', '2'], [15, 'abc', '2'],
+      [5, 'abc', '23'], [16, 'abc', '23'],
+      [6, 'abc', '123'], [17, 'abc', '123'],
+      [7, 'abc', '128'], [18, 'abc', '128'],
+      [8, 'abc', '129'], [19, 'abc', '129'],
+      [9, 'abc', '128'],
+      [20, 'abc'], [10, 'abc']
+    ]
 
     wb0 = read_wb("#{wb_path}/0.wb")
     assert_equal(18, wb0.length)
     i = 0
-    wb0.each do |last, cmd, key, val|
+    wb0.each do |_last, cmd, key, val|
       # puts "#{cmd} #{key} #{val.inspect}"
       assert_equal(res[i][0], cmd)
       assert_equal(res[i][1], key)
@@ -349,49 +344,49 @@ class WriteBehindTest < Test::Unit::TestCase
 
   def test_wb2_alist_commands
     h = {
-      :alist_clear=>1,
-      :alist_delete=>2,
-      :alist_delete_at=>3,
-      :alist_insert=>4,
-      :alist_sized_insert=>5,
-      :alist_swap_and_insert=>6,
-      :alist_swap_and_sized_insert=>7,
-      :alist_expired_swap_and_insert=>8,
-      :alist_expired_swap_and_sized_insert=>9,
-      :alist_push=>10,
-      :alist_sized_push=>11,
-      :alist_swap_and_push=>12,
-      :alist_swap_and_sized_push=>13,
-      :alist_expired_swap_and_push=>14,
-      :alist_expired_swap_and_sized_push=>15,
-      :alist_update_at=>16
+      alist_clear: 1,
+      alist_delete: 2,
+      alist_delete_at: 3,
+      alist_insert: 4,
+      alist_sized_insert: 5,
+      alist_swap_and_insert: 6,
+      alist_swap_and_sized_insert: 7,
+      alist_expired_swap_and_insert: 8,
+      alist_expired_swap_and_sized_insert: 9,
+      alist_push: 10,
+      alist_sized_push: 11,
+      alist_swap_and_push: 12,
+      alist_swap_and_sized_push: 13,
+      alist_expired_swap_and_push: 14,
+      alist_expired_swap_and_sized_push: 15,
+      alist_update_at: 16
     }
-    send_cmd("localhost_11211", "wb_command_map #{h}")
-    assert_equal('STORED', @rc.alist_push("abc","1")) # ['1']
-    assert_equal('STORED', @rc.alist_insert("abc",0,"2")) #['2','1']
-    assert_equal('STORED', @rc.alist_sized_insert("abc",5,"3")) #['3','2','1']
-    assert_equal('STORED', @rc.alist_swap_and_insert("abc","4")) #['4','3','2','1']
-    assert_equal('STORED', @rc.alist_swap_and_sized_insert("abc",5,"5")) #['5','4','3','2','1']
-    assert_equal('STORED', @rc.alist_expired_swap_and_insert("abc",100,"6")) #['6','5','4','3','2','1']
-    assert_equal('STORED', @rc.alist_expired_swap_and_sized_insert("abc",100,10,"7")) #['7','6','5','4','3','2','1']
-    assert_equal('STORED', @rc.alist_sized_push("abc",10,"8")) #['7','6','5','4','3','2','1','8']
-    assert_equal('STORED', @rc.alist_swap_and_push("abc","9")) #['7','6','5','4','3','2','1','8','9']
-    assert_equal('STORED', @rc.alist_swap_and_sized_push("abc",10,"10")) #['7','6','5','4','3','2','1','8','9','10']
-    assert_equal('STORED', @rc.alist_expired_swap_and_push("abc",100,"11")) #['7','6','5','4','3','2','1','8','9','10','11']
-    assert_equal('STORED', @rc.alist_expired_swap_and_sized_push("abc",100,12,"12")) #['7','6','5','4','3','2','1','8','9','10','12']
-    assert_equal('STORED', @rc.alist_update_at("abc",0,"13")) #['13','6','5','4','3','2','1','8','9','10','12']
-    assert_equal('DELETED', @rc.alist_delete("abc","3") ) #['13','6','5','4','2','1','8','9','10','12']
-    assert_equal('DELETED', @rc.alist_delete_at("abc",1)) #['13','5','4','2','1','8','9','10','12']
-    assert_equal('CLEARED', @rc.alist_clear("abc"))
-    send_cmd("localhost_11211", "writebehind_rotate roma")
+    send_cmd('localhost_11211', "wb_command_map #{h}")
+    assert_equal('STORED', @rc.alist_push('abc', '1')) # ['1']
+    assert_equal('STORED', @rc.alist_insert('abc', 0, '2')) # ['2','1']
+    assert_equal('STORED', @rc.alist_sized_insert('abc', 5, '3')) # ['3','2','1']
+    assert_equal('STORED', @rc.alist_swap_and_insert('abc', '4')) # ['4','3','2','1']
+    assert_equal('STORED', @rc.alist_swap_and_sized_insert('abc', 5, '5')) # ['5','4','3','2','1']
+    assert_equal('STORED', @rc.alist_expired_swap_and_insert('abc', 100, '6')) # ['6','5','4','3','2','1']
+    assert_equal('STORED', @rc.alist_expired_swap_and_sized_insert('abc', 100, 10, '7')) # ['7','6','5','4','3','2','1']
+    assert_equal('STORED', @rc.alist_sized_push('abc', 10, '8')) # ['7','6','5','4','3','2','1','8']
+    assert_equal('STORED', @rc.alist_swap_and_push('abc', '9')) # ['7','6','5','4','3','2','1','8','9']
+    assert_equal('STORED', @rc.alist_swap_and_sized_push('abc', 10, '10')) # ['7','6','5','4','3','2','1','8','9','10']
+    assert_equal('STORED', @rc.alist_expired_swap_and_push('abc', 100, '11')) # ['7','6','5','4','3','2','1','8','9','10','11']
+    assert_equal('STORED', @rc.alist_expired_swap_and_sized_push('abc', 100, 12, '12')) # ['7','6','5','4','3','2','1','8','9','10','12']
+    assert_equal('STORED', @rc.alist_update_at('abc', 0, '13')) # ['13','6','5','4','3','2','1','8','9','10','12']
+    assert_equal('DELETED', @rc.alist_delete('abc', '3')) # ['13','6','5','4','2','1','8','9','10','12']
+    assert_equal('DELETED', @rc.alist_delete_at('abc', 1)) # ['13','5','4','2','1','8','9','10','12']
+    assert_equal('CLEARED', @rc.alist_clear('abc'))
+    send_cmd('localhost_11211', 'writebehind_rotate roma')
 
     res = {
-      10=>'1',4=>'2',5=>'3',6=>'4',7=>'5',8=>'6',9=>'7',11=>'8',12=>'9',
-      13=>'10',14=>'11',15=>'12',16=>'13',2=>'3',3=>'6',
-      1=>["13", "5", "4", "2", "1", "8", "9", "10", "11", "12"]}
+      10 => '1', 4 => '2', 5 => '3', 6 => '4', 7 => '5', 8 => '6', 9 => '7', 11 => '8', 12 => '9',
+      13 => '10', 14 => '11', 15 => '12', 16 => '13', 2 => '3', 3 => '6',
+      1 => %w(13 5 4 2 1 8 9 10 11 12) }
     wb0 = read_wb("#{wb_path}/0.wb")
     assert_equal(16, wb0.length)
-    wb0.each do |last, cmd, key, val|
+    wb0.each do |_last, cmd, _key, val|
       begin
         val = Marshal.load(val)[0]
       rescue
@@ -403,21 +398,21 @@ class WriteBehindTest < Test::Unit::TestCase
 
   def test_wb2_map_commands
     h = {
-      :map_set=>1,
-      :map_delete=>2,
-      :map_clear=>3
+      map_set: 1,
+      map_delete: 2,
+      map_clear: 3
     }
-    send_cmd("localhost_11211", "wb_command_map #{h}")
-    assert_equal('STORED', @rc.map_set('abc','mapkey1','value1'))
+    send_cmd('localhost_11211', "wb_command_map #{h}")
+    assert_equal('STORED', @rc.map_set('abc', 'mapkey1', 'value1'))
     assert_equal('DELETED', @rc.map_delete('abc', 'mapkey1'))
-    assert_equal('STORED', @rc.map_set('abc','mapkey1','value1'))
-    assert_equal('CLEARED', @rc.map_clear("abc"))
-    send_cmd("localhost_11211", "writebehind_rotate roma")
+    assert_equal('STORED', @rc.map_set('abc', 'mapkey1', 'value1'))
+    assert_equal('CLEARED', @rc.map_clear('abc'))
+    send_cmd('localhost_11211', 'writebehind_rotate roma')
 
-    res = {1=>{"mapkey1"=>"value1"},2=>{},3=>{}}
+    res = { 1 => { 'mapkey1' => 'value1' }, 2 => {}, 3 => {} }
     wb0 = read_wb("#{wb_path}/0.wb")
     assert_equal(4, wb0.length)
-    wb0.each do |last, cmd, key, val|
+    wb0.each do |_last, cmd, _key, val|
       begin
         val = Marshal.load(val)
       rescue
@@ -429,36 +424,36 @@ class WriteBehindTest < Test::Unit::TestCase
 
   def test_wb2_map_commands2
     h = {
-      :map_set=>1, :map_set__prev=>11, 
-      :map_delete=>2, :map_delete__prev=>12,
-      :map_clear=>3, :map_clear__prev=>13
+      map_set: 1, map_set__prev: 11,
+      map_delete: 2, map_delete__prev: 12,
+      map_clear: 3, map_clear__prev: 13
     }
-    send_cmd("localhost_11211", "wb_command_map #{h}")
-    assert_equal('STORED', @rc.map_set('abc','mapkey1','value1'))
-    assert_equal('STORED', @rc.map_set('abc','mapkey2','value2'))
+    send_cmd('localhost_11211', "wb_command_map #{h}")
+    assert_equal('STORED', @rc.map_set('abc', 'mapkey1', 'value1'))
+    assert_equal('STORED', @rc.map_set('abc', 'mapkey2', 'value2'))
     assert_equal('DELETED', @rc.map_delete('abc', 'mapkey1'))
-    assert_equal('STORED', @rc.map_set('abc','mapkey1','value1'))
-    assert_equal('CLEARED', @rc.map_clear("abc"))
-    send_cmd("localhost_11211", "writebehind_rotate roma")
+    assert_equal('STORED', @rc.map_set('abc', 'mapkey1', 'value1'))
+    assert_equal('CLEARED', @rc.map_clear('abc'))
+    send_cmd('localhost_11211', 'writebehind_rotate roma')
 
     res = [
-           [1, {"mapkey1"=>"value1"}],
-           [11, {"mapkey1"=>"value1"}], [1, {"mapkey1"=>"value1", "mapkey2"=>"value2"}],
-           [12, {"mapkey1"=>"value1", "mapkey2"=>"value2"}], [2, {"mapkey2"=>"value2"}],
-           [11, {"mapkey2"=>"value2"}], [1, {"mapkey2"=>"value2", "mapkey1"=>"value1"}],
-           [13, {"mapkey2"=>"value2", "mapkey1"=>"value1"}], [3, {}]
+      [1, { 'mapkey1' => 'value1' }],
+      [11, { 'mapkey1' => 'value1' }], [1, { 'mapkey1' => 'value1', 'mapkey2' => 'value2' }],
+      [12, { 'mapkey1' => 'value1', 'mapkey2' => 'value2' }], [2, { 'mapkey2' => 'value2' }],
+      [11, { 'mapkey2' => 'value2' }], [1, { 'mapkey2' => 'value2', 'mapkey1' => 'value1' }],
+      [13, { 'mapkey2' => 'value2', 'mapkey1' => 'value1' }], [3, {}]
 
     ]
     wb0 = read_wb("#{wb_path}/0.wb")
     assert_equal(res.length, wb0.length)
     cnt = 0
-    wb0.each do |last, cmd, key, val|
+    wb0.each do |_last, cmd, _key, val|
       begin
         val = Marshal.load(val)
       rescue
       end
-      #puts "#{cmd} #{key} #{val.inspect}"
-       assert_equal(res[cnt][0], cmd)
+      # puts "#{cmd} #{key} #{val.inspect}"
+      assert_equal(res[cnt][0], cmd)
       assert_equal(res[cnt][1], val)
       cnt += 1
     end
@@ -477,10 +472,10 @@ class WriteBehindTest < Test::Unit::TestCase
   end
 
   def wb_hostname
-    if File.exist?("wb/localhost_11211")
-      "localhost_11211"
-    elsif File.exist?("wb/localhost_11212")
-      "localhost_11212"
+    if File.exist?('wb/localhost_11211')
+      'localhost_11211'
+    elsif File.exist?('wb/localhost_11212')
+      'localhost_11212'
     else
       nil
     end


### PR DESCRIPTION
This pull request will resolve #46 issue. And this pull request include some refactoring for tests like remove verbose standard outputs.

Following pull request for roma-ruby-client is required to run this.
https://github.com/roma/roma-ruby-client/pull/5

If you want to execute only new test, please execute like this.

```
bundle exec test/run-test.rb -v -t RoutingLogicTest
```

Thanks!