### PR TITLE
add shutdown_self command

### DIFF
--- a/lib/roma/command/sys_command_receiver.rb
+++ b/lib/roma/command/sys_command_receiver.rb
@@ -39,19 +39,55 @@ module Roma
         @stop_event_loop = true
       end
 
-      # shutdown_instance [node-id]
-      def ev_shutdown_instance(s)
-        if s.length != 2
-          send_data("usage:shutdown_instance [node-id]\r\n")
+      # shutdown [reason]
+      def ev_shutdown(s)
+        send_data("*** ARE YOU REALLY SURE TO SHUTDOWN? *** (yes/no)\r\n")
+        if gets != "yes\r\n"
+          close_connection_after_writing
+          return
+        end
+
+        if s.length == 2
+          @log.info("Receive a shutdown #{s[1]}")
         else
-          if s[1] == @stats.ap_str
-            @rttable.enabled_failover = false
-            send_data("BYE\r\n")
-            @stop_event_loop = true
+          @log.info("Receive a shutdown command.")
+        end
+        @rttable.enabled_failover = false
+        res = broadcast_cmd("rshutdown\r\n")
+        res[@stats.ap_str] = "BYE"
+        send_data("#{res.inspect}\r\n")
+        close_connection_after_writing
+        @stop_event_loop = true
+      end
+
+      # rshutdown [reason]
+      def ev_rshutdown(s)
+        if s.length == 2
+          @log.info("Receive a rshutdown #{s[1]}")
+        else
+          @log.info("Receive a rshutdown command.")
+        end
+        @rttable.enabled_failover = false
+        send_data("BYE\r\n")
+        close_connection_after_writing
+        @stop_event_loop = true
+      end
+
+      # shutdown_self
+      def ev_shutdown_self(s)
+        if s.length != 1
+          send_data("ERROR: shutdown_instance has irregular argument.\r\n")
+        else
+          send_data("Are you sure to shutdown this instance?(yes/no)\r\n")
+          if gets != "yes\r\n"
             close_connection_after_writing
-          else
-            send_data("invalid [node-id]\r\n")
+            return
           end
+          @log.info("Receive a shutdown_self command.")
+          @rttable.enabled_failover = false
+          send_data("BYE\r\n")
+          @stop_event_loop = true
+          close_connection_after_writing
         end
       end
 

--- a/lib/roma/command/sys_command_receiver.rb
+++ b/lib/roma/command/sys_command_receiver.rb
@@ -78,7 +78,10 @@ module Roma
         if s.length != 1
           send_data("ERROR: shutdown_instance has irregular argument.\r\n")
         else
-          send_data("Are you sure to shutdown this instance?(yes/no)\r\n")
+          send_data("\r\n=================================================================\r\n")
+          send_data("CAUTION!!: \r\n\tThis command kill the instance!\r\n\tThere is some possibility of occuring redundancy down!\r\n")
+          send_data("=================================================================\r\n")
+          send_data("\r\nAre you sure to shutdown this instance?(yes/no)\r\n")
           if gets != "yes\r\n"
             close_connection_after_writing
             return

--- a/lib/roma/plugin/plugin_cmd_aliases.rb
+++ b/lib/roma/plugin/plugin_cmd_aliases.rb
@@ -5,38 +5,7 @@ module Roma
     module PluginCommandAliases
       include ::Roma::CommandPlugin
 
-      # shutdown [reason]
-      def ev_shutdown(s)
-        send_data("*** ARE YOU REALLY SURE TO SHUTDOWN? *** (yes/no)\r\n")
-        if gets != "yes\r\n"
-          close_connection_after_writing
-          return
-        end
-
-        if s.length == 2
-          @log.info("Receive a shutdown #{s[1]}")
-        else
-          @log.info("Receive a shutdown command.")
-        end
-        @rttable.enabled_failover = false
-        res = broadcast_cmd("rshutdown\r\n")
-        send_data("#{res.inspect}\r\n")
-        close_connection_after_writing
-        @stop_event_loop = true
-      end
-
-      # rshutdown [reason]
-      def ev_rshutdown(s)
-        if s.length == 2
-          @log.info("Receive a rshutdown #{s[1]}")
-        else
-          @log.info("Receive a rshutdown command.")
-        end
-        @rttable.enabled_failover = false
-        send_data("BYE\r\n")
-        close_connection_after_writing
-        @stop_event_loop = true
-      end
+      # Please add your self if you want.
 
     end
   end


### PR DESCRIPTION
- I moved "shutdown" and "rshutdown" command from alias plugin to sys command receiver.
  - And I added information of self instance when executing like a balse.
- add confirmation to rbalse commad?
  - I think better that "r****" command is just send other instance command and not good to use as a general user command.
  - I will re-use shutdown_instance command.
- shutdown_instance command
  - This command require node-id as a argument, but it can not kill the other process, only self process.
  - I change name to shutdown_self
  - I added confirmation message like a "balse" command.
- Should we add caution message when it have possibility of generation short vnodes?
  - There is risk of uncatching, so I added in everytime.
- Should we make new command which compact rbalse and  release command?
  - I thinki it is little danger that we can NOT know when instance will be down, so I did NOT add this pull request.