### PR TITLE
enable to check failover status

### DIFF
--- a/lib/roma/routing/cb_rttable.rb
+++ b/lib/roma/routing/cb_rttable.rb
@@ -22,6 +22,7 @@ module Roma
       attr_accessor :event
       attr_accessor :event_limit_line
       attr_accessor :logs
+      attr_accessor :enabled_failover
       attr_reader :version_of_nodes
       attr_reader :min_version
 
@@ -57,6 +58,7 @@ module Roma
         ret['routing.event_limit_line'] = @event_limit_line
         ret['routing.version_of_nodes'] = @version_of_nodes.inspect
         ret['routing.min_version'] = @min_version
+        ret['routing.enabled_failover'] = @enabled_failover
         ret
       end
 


### PR DESCRIPTION
stats

    stat failover
    routing.enabled_failover true
    END
    
    switch_failover off
    {"192.168.33.12_10001"=>"DISABLED", "192.168.33.12_10003"=>"DISABLED", "192.168.33.12_10002"=>"DISABLED"}
    
    stat failover
    routing.enabled_failover false
    END

Log

    ==> logs/192.168.33.12_10001.log <==
    W, [2015-06-29T15:06:10.653797 #28161]  WARN -- : failover disable now!!
    
    ==> logs/192.168.33.12_10002.log <==
    W, [2015-06-29T15:06:11.131874 #28172]  WARN -- : failover disable now!!
    
    ==> logs/192.168.33.12_10003.log <==
    W, [2015-06-29T15:06:11.704907 #28183]  WARN -- : failover disable now!!