### PR TITLE
modify unit test

### DIFF
--- a/test/roma-test-utils.rb
+++ b/test/roma-test-utils.rb
@@ -19,7 +19,7 @@ module RomaTestUtils
   DEFAULT_IP = '127.0.0.1'
   DEFAULT_PORTS = %w(11211 11212)
   DEFAULT_NODES = DEFAULT_PORTS.map { |port| "#{DEFAULT_HOST}_#{port}" }
-  DEFAULT_TIMEOUT_SEC = 60
+  DEFAULT_TIMEOUT_SEC = 90
   SHELL_LOG = 'roma_test_outputs.log'
 
   Roma::Logging::RLogger.create_singleton_instance("#{Roma::Config::LOG_PATH}/roma_test.log",
@@ -61,14 +61,14 @@ module RomaTestUtils
     system(romad_command.join(' '))
   end
 
-  def get_client(node=DEFAULT_NODES)
+  def get_client
     client_pool = Roma::Client::ClientPool.instance
-    client_pool.servers = node
+    client_pool.servers = DEFAULT_NODES
     client_pool.client
   end
 
   def wait_join(node)
-    client = get_client([node])
+    client = get_client
     wait_count = 0
     retry_count = 0
     sleep 5
@@ -80,7 +80,7 @@ module RomaTestUtils
       fail "#{__method__} timeout" if wait_count > DEFAULT_TIMEOUT_SEC
     end
 
-    while client.stats['stats.run_join'] == 'true'
+    while client.stats(node: node)['stats.run_join'] == 'true'
       sleep 1
       wait_count += 1
       fail "#{__method__} timeout" if wait_count > DEFAULT_TIMEOUT_SEC

--- a/test/roma-test-utils.rb
+++ b/test/roma-test-utils.rb
@@ -61,14 +61,14 @@ module RomaTestUtils
     system(romad_command.join(' '))
   end
 
-  def get_client
+  def get_client(node=DEFAULT_NODES)
     client_pool = Roma::Client::ClientPool.instance
-    client_pool.servers = DEFAULT_NODES
+    client_pool.servers = node
     client_pool.client
   end
 
   def wait_join(node)
-    client = get_client
+    client = get_client([node])
     wait_count = 0
     retry_count = 0
     sleep 5
@@ -80,7 +80,7 @@ module RomaTestUtils
       fail "#{__method__} timeout" if wait_count > DEFAULT_TIMEOUT_SEC
     end
 
-    while client.stats(node: node)['stats.run_join'] == 'true'
+    while client.stats['stats.run_join'] == 'true'
       sleep 1
       wait_count += 1
       fail "#{__method__} timeout" if wait_count > DEFAULT_TIMEOUT_SEC

--- a/test/t_routing_logic.rb
+++ b/test/t_routing_logic.rb
@@ -32,84 +32,84 @@ class RoutingLogicTest < Test::Unit::TestCase
       assert_match(/#{new_node}/, stats['routing.nodes'])
       assert_not_equal(0, stats['routing.secondary'].to_i)
     end
-#
-#    new_node = new_nodes.last
 
-#    # Release and stop a node
-#    release_roma_node(new_node)
-#    wait_release(new_node)
-#    stop_roma_node(new_node)
-#    wait_failover(new_node)
-#    stats = client.stats
-#    assert_no_match(/#{new_node}/, stats['routing.nodes'])
-#    assert_equal(0, stats['routing.short_vnodes'].to_i)
-#
-#    # Join a node without short vnodes
-#    join_roma(new_node, replication_in_host: replication_in_host)
-#    wait_join(new_node)
-#    stats = client.stats(node: new_node)
-#    assert_match(/#{new_node}/, stats['routing.nodes'])
-#    assert_not_equal(0, stats['routing.secondary'].to_i)
-#
-#    # Stop a node and generate short vnodes
-#    stop_roma_node(new_node)
-#    wait_failover(new_node)
-#    stats = client.stats
-#    assert_no_match(/#{new_node}/, stats['routing.nodes'])
-#    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
-#
-#    # Join a node with short vnodes
-#    join_roma(new_node, replication_in_host: replication_in_host)
-#    wait_join(new_node)
-#    stats = client.stats(node: new_node)
-#    assert_match(/#{new_node}/, stats['routing.nodes'])
-#    assert_not_equal(0, stats['routing.secondary'].to_i)
+    new_node = new_nodes.last
+
+    # Release and stop a node
+    release_roma_node(new_node)
+    wait_release(new_node)
+    stop_roma_node(new_node)
+    wait_failover(new_node)
+    stats = client.stats
+    assert_no_match(/#{new_node}/, stats['routing.nodes'])
+    assert_equal(0, stats['routing.short_vnodes'].to_i)
+
+    # Join a node without short vnodes
+    join_roma(new_node, replication_in_host: replication_in_host)
+    wait_join(new_node)
+    stats = client.stats(node: new_node)
+    assert_match(/#{new_node}/, stats['routing.nodes'])
+    assert_not_equal(0, stats['routing.secondary'].to_i)
+
+    # Stop a node and generate short vnodes
+    stop_roma_node(new_node)
+    wait_failover(new_node)
+    stats = client.stats
+    assert_no_match(/#{new_node}/, stats['routing.nodes'])
+    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
+
+    # Join a node with short vnodes
+    join_roma(new_node, replication_in_host: replication_in_host)
+    wait_join(new_node)
+    stats = client.stats(node: new_node)
+    assert_match(/#{new_node}/, stats['routing.nodes'])
+    assert_not_equal(0, stats['routing.secondary'].to_i)
    end
 
-#  def test_routing_logic_join_when_num_of_hosts_changing
-#    replication_in_host = false
-#    same_host_node = "#{DEFAULT_HOST}_#{NEW_PORTS[0]}"
-#    other_host_node = "#{DEFAULT_IP}_#{NEW_PORTS[1]}"
-#
-#    start_roma(div_bits: 6, replication_in_host: replication_in_host)
-#    sleep 12 # Wait cluster starting, otherwise join will never finish
-#    client = get_client
-#
-#    # Join other_host_node
-#    join_roma(other_host_node, replication_in_host: replication_in_host)
-#    wait_join(other_host_node)
-#    stats = client.stats(node: other_host_node)
-#    assert_match(/#{other_host_node}/, stats['routing.nodes'])
-#    assert_not_equal(0, stats['routing.secondary'].to_i)
-#
-#    # Stop other_host_node and generate short vnodes
-#    stop_roma_node(other_host_node)
-#    wait_failover(other_host_node)
-#    stats = client.stats
-#    assert_no_match(/#{other_host_node}/, stats['routing.nodes'])
-#    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
-#
-#    # Join other_host_node
-#    join_roma(other_host_node, replication_in_host: replication_in_host)
-#    wait_join(other_host_node)
-#    stats = client.stats(node: other_host_node)
-#    assert_match(/#{other_host_node}/, stats['routing.nodes'])
-#    assert_not_equal(0, stats['routing.secondary'].to_i)
-#
-#    # Stop other_host_node and generate short vnodes
-#    stop_roma_node(other_host_node)
-#    wait_failover(other_host_node)
-#    stats = client.stats
-#    assert_no_match(/#{other_host_node}/, stats['routing.nodes'])
-#    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
-#
-#    # Join same_host_node (secondary will be 0 in this case)
-#    join_roma(same_host_node, replication_in_host: replication_in_host)
-#    wait_join(same_host_node)
-#    stats = client.stats(node: same_host_node)
-#    assert_match(/#{same_host_node}/, stats['routing.nodes'])
-#    assert_equal(0, stats['routing.secondary'].to_i)
-#  end
+  def test_routing_logic_join_when_num_of_hosts_changing
+    replication_in_host = false
+    same_host_node = "#{DEFAULT_HOST}_#{NEW_PORTS[0]}"
+    other_host_node = "#{DEFAULT_IP}_#{NEW_PORTS[1]}"
+
+    start_roma(div_bits: 6, replication_in_host: replication_in_host)
+    sleep 12 # Wait cluster starting, otherwise join will never finish
+    client = get_client
+
+    # Join other_host_node
+    join_roma(other_host_node, replication_in_host: replication_in_host)
+    wait_join(other_host_node)
+    stats = client.stats(node: other_host_node)
+    assert_match(/#{other_host_node}/, stats['routing.nodes'])
+    assert_not_equal(0, stats['routing.secondary'].to_i)
+
+    # Stop other_host_node and generate short vnodes
+    stop_roma_node(other_host_node)
+    wait_failover(other_host_node)
+    stats = client.stats
+    assert_no_match(/#{other_host_node}/, stats['routing.nodes'])
+    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
+
+    # Join other_host_node
+    join_roma(other_host_node, replication_in_host: replication_in_host)
+    wait_join(other_host_node)
+    stats = client.stats(node: other_host_node)
+    assert_match(/#{other_host_node}/, stats['routing.nodes'])
+    assert_not_equal(0, stats['routing.secondary'].to_i)
+
+    # Stop other_host_node and generate short vnodes
+    stop_roma_node(other_host_node)
+    wait_failover(other_host_node)
+    stats = client.stats
+    assert_no_match(/#{other_host_node}/, stats['routing.nodes'])
+    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
+
+    # Join same_host_node (secondary will be 0 in this case)
+    join_roma(same_host_node, replication_in_host: replication_in_host)
+    wait_join(same_host_node)
+    stats = client.stats(node: same_host_node)
+    assert_match(/#{same_host_node}/, stats['routing.nodes'])
+    assert_equal(0, stats['routing.secondary'].to_i)
+  end
 
   # TODO: recover, balance command tests
 end

--- a/test/t_routing_logic.rb
+++ b/test/t_routing_logic.rb
@@ -1,7 +1,12 @@
 #!/usr/bin/env ruby
 
+require '/usr/local/rvm/gems/ruby-2.1.2/gems/test-unit-3.1.2/lib/test/unit/data' # todo
+require '/usr/local/rvm/gems/ruby-2.1.2/gems/test-unit-3.1.2/lib/test/unit/attribute' # todo
+
 class RoutingLogicTest < Test::Unit::TestCase
   include RomaTestUtils
+  include Test::Unit::Data
+  include Test::Unit::Attribute
 
   NEW_PORTS = %w(11213 11214)
 
@@ -11,17 +16,15 @@ class RoutingLogicTest < Test::Unit::TestCase
     puts "#{e} #{$ERROR_POSITION}"
   end
 
-  data = {
-  'single_host' => [
-    true,
-    NEW_PORTS.map { |port| "#{DEFAULT_HOST}_#{port}" }],
-  'multiple_hosts' => [
-    false,
-    NEW_PORTS.map { |port| "#{DEFAULT_IP}_#{port}" }],
-  'multiple_hosts_include_some_hosts' => [
-    false,
-    ["#{DEFAULT_IP}_#{NEW_PORTS[0]}", "#{DEFAULT_HOST}_#{NEW_PORTS[1]}"]]
-  }
+  a = data(
+       'single_host' => [true, NEW_PORTS.map { |port| "#{DEFAULT_HOST}_#{port}" }],
+       #'multiple_hosts' => [false, NEW_PORTS.map { |port| "#{DEFAULT_IP}_#{port}" }],
+       #'multiple_hosts_include_some_hosts' => [false, ["#{DEFAULT_IP}_#{NEW_PORTS[0]}", "#{DEFAULT_HOST}_#{NEW_PORTS[1]}"]]
+  )
+
+  puts "asdfadsf"
+  puts a
+  puts "asdfadsf"
 
   def test_join(data)
     replication_in_host, new_nodes = data
@@ -29,7 +32,7 @@ class RoutingLogicTest < Test::Unit::TestCase
     sleep 12 # Wait cluster starting, otherwise join will never finish
     client = get_client
 
-    # Join nodes
+   # Join nodes
     assert_equal(DEFAULT_NODES.size, client.rttable.nodes.size)
     new_nodes.each do |new_node|
       join_roma(new_node, replication_in_host: replication_in_host)
@@ -70,52 +73,52 @@ class RoutingLogicTest < Test::Unit::TestCase
     stats = client.stats(node: new_node)
     assert_match(/#{new_node}/, stats['routing.nodes'])
     assert_not_equal(0, stats['routing.secondary'].to_i)
-  end
-
-  def test_join_when_num_of_hosts_changing
-    replication_in_host = false
-    same_host_node = "#{DEFAULT_HOST}_#{NEW_PORTS[0]}"
-    other_host_node = "#{DEFAULT_IP}_#{NEW_PORTS[1]}"
-
-    start_roma(div_bits: 6, replication_in_host: replication_in_host)
-    sleep 12 # Wait cluster starting, otherwise join will never finish
-    client = get_client
-
-    # Join other_host_node
-    join_roma(other_host_node, replication_in_host: replication_in_host)
-    wait_join(other_host_node)
-    stats = client.stats(node: other_host_node)
-    assert_match(/#{other_host_node}/, stats['routing.nodes'])
-    assert_not_equal(0, stats['routing.secondary'].to_i)
-
-    # Stop other_host_node and generate short vnodes
-    stop_roma_node(other_host_node)
-    wait_failover(other_host_node)
-    stats = client.stats
-    assert_no_match(/#{other_host_node}/, stats['routing.nodes'])
-    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
-
-    # Join other_host_node
-    join_roma(other_host_node, replication_in_host: replication_in_host)
-    wait_join(other_host_node)
-    stats = client.stats(node: other_host_node)
-    assert_match(/#{other_host_node}/, stats['routing.nodes'])
-    assert_not_equal(0, stats['routing.secondary'].to_i)
-
-    # Stop other_host_node and generate short vnodes
-    stop_roma_node(other_host_node)
-    wait_failover(other_host_node)
-    stats = client.stats
-    assert_no_match(/#{other_host_node}/, stats['routing.nodes'])
-    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
-
-    # Join same_host_node (secondary will be 0 in this case)
-    join_roma(same_host_node, replication_in_host: replication_in_host)
-    wait_join(same_host_node)
-    stats = client.stats(node: same_host_node)
-    assert_match(/#{same_host_node}/, stats['routing.nodes'])
-    assert_equal(0, stats['routing.secondary'].to_i)
-  end
+   end
+#
+#  def test_join_when_num_of_hosts_changing
+#    replication_in_host = false
+#    same_host_node = "#{DEFAULT_HOST}_#{NEW_PORTS[0]}"
+#    other_host_node = "#{DEFAULT_IP}_#{NEW_PORTS[1]}"
+#
+#    start_roma(div_bits: 6, replication_in_host: replication_in_host)
+#    sleep 12 # Wait cluster starting, otherwise join will never finish
+#    client = get_client
+#
+#    # Join other_host_node
+#    join_roma(other_host_node, replication_in_host: replication_in_host)
+#    wait_join(other_host_node)
+#    stats = client.stats(node: other_host_node)
+#    assert_match(/#{other_host_node}/, stats['routing.nodes'])
+#    assert_not_equal(0, stats['routing.secondary'].to_i)
+#
+#    # Stop other_host_node and generate short vnodes
+#    stop_roma_node(other_host_node)
+#    wait_failover(other_host_node)
+#    stats = client.stats
+#    assert_no_match(/#{other_host_node}/, stats['routing.nodes'])
+#    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
+#
+#    # Join other_host_node
+#    join_roma(other_host_node, replication_in_host: replication_in_host)
+#    wait_join(other_host_node)
+#    stats = client.stats(node: other_host_node)
+#    assert_match(/#{other_host_node}/, stats['routing.nodes'])
+#    assert_not_equal(0, stats['routing.secondary'].to_i)
+#
+#    # Stop other_host_node and generate short vnodes
+#    stop_roma_node(other_host_node)
+#    wait_failover(other_host_node)
+#    stats = client.stats
+#    assert_no_match(/#{other_host_node}/, stats['routing.nodes'])
+#    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
+#
+#    # Join same_host_node (secondary will be 0 in this case)
+#    join_roma(same_host_node, replication_in_host: replication_in_host)
+#    wait_join(same_host_node)
+#    stats = client.stats(node: same_host_node)
+#    assert_match(/#{same_host_node}/, stats['routing.nodes'])
+#    assert_equal(0, stats['routing.secondary'].to_i)
+#  end
 
   # TODO: recover, balance command tests
 end

--- a/test/t_routing_logic.rb
+++ b/test/t_routing_logic.rb
@@ -1,12 +1,7 @@
 #!/usr/bin/env ruby
 
-require '/usr/local/rvm/gems/ruby-2.1.2/gems/test-unit-3.1.2/lib/test/unit/data' # todo
-require '/usr/local/rvm/gems/ruby-2.1.2/gems/test-unit-3.1.2/lib/test/unit/attribute' # todo
-
 class RoutingLogicTest < Test::Unit::TestCase
   include RomaTestUtils
-  include Test::Unit::Data
-  include Test::Unit::Attribute
 
   NEW_PORTS = %w(11213 11214)
 
@@ -16,18 +11,14 @@ class RoutingLogicTest < Test::Unit::TestCase
     puts "#{e} #{$ERROR_POSITION}"
   end
 
-  a = data(
-       'single_host' => [true, NEW_PORTS.map { |port| "#{DEFAULT_HOST}_#{port}" }],
-       #'multiple_hosts' => [false, NEW_PORTS.map { |port| "#{DEFAULT_IP}_#{port}" }],
-       #'multiple_hosts_include_some_hosts' => [false, ["#{DEFAULT_IP}_#{NEW_PORTS[0]}", "#{DEFAULT_HOST}_#{NEW_PORTS[1]}"]]
-  )
+  @@data= {
+    'single_host' => [true, NEW_PORTS.map { |port| "#{DEFAULT_HOST}_#{port}" }],
+    'multiple_hosts' => [false, NEW_PORTS.map { |port| "#{DEFAULT_IP}_#{port}" }],
+    'multiple_hosts_include_some_hosts' => [false, ["#{DEFAULT_IP}_#{NEW_PORTS[0]}", "#{DEFAULT_HOST}_#{NEW_PORTS[1]}"]]
+  }
 
-  puts "asdfadsf"
-  puts a
-  puts "asdfadsf"
-
-  def test_join(data)
-    replication_in_host, new_nodes = data
+  def test_routing_logic_join
+    replication_in_host, new_nodes = @@data['single_host']
     start_roma(div_bits: 6, replication_in_host: replication_in_host)
     sleep 12 # Wait cluster starting, otherwise join will never finish
     client = get_client
@@ -41,41 +32,41 @@ class RoutingLogicTest < Test::Unit::TestCase
       assert_match(/#{new_node}/, stats['routing.nodes'])
       assert_not_equal(0, stats['routing.secondary'].to_i)
     end
-
-    new_node = new_nodes.last
-
-    # Release and stop a node
-    release_roma_node(new_node)
-    wait_release(new_node)
-    stop_roma_node(new_node)
-    wait_failover(new_node)
-    stats = client.stats
-    assert_no_match(/#{new_node}/, stats['routing.nodes'])
-    assert_equal(0, stats['routing.short_vnodes'].to_i)
-
-    # Join a node without short vnodes
-    join_roma(new_node, replication_in_host: replication_in_host)
-    wait_join(new_node)
-    stats = client.stats(node: new_node)
-    assert_match(/#{new_node}/, stats['routing.nodes'])
-    assert_not_equal(0, stats['routing.secondary'].to_i)
-
-    # Stop a node and generate short vnodes
-    stop_roma_node(new_node)
-    wait_failover(new_node)
-    stats = client.stats
-    assert_no_match(/#{new_node}/, stats['routing.nodes'])
-    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
-
-    # Join a node with short vnodes
-    join_roma(new_node, replication_in_host: replication_in_host)
-    wait_join(new_node)
-    stats = client.stats(node: new_node)
-    assert_match(/#{new_node}/, stats['routing.nodes'])
-    assert_not_equal(0, stats['routing.secondary'].to_i)
-   end
 #
-#  def test_join_when_num_of_hosts_changing
+#    new_node = new_nodes.last
+
+#    # Release and stop a node
+#    release_roma_node(new_node)
+#    wait_release(new_node)
+#    stop_roma_node(new_node)
+#    wait_failover(new_node)
+#    stats = client.stats
+#    assert_no_match(/#{new_node}/, stats['routing.nodes'])
+#    assert_equal(0, stats['routing.short_vnodes'].to_i)
+#
+#    # Join a node without short vnodes
+#    join_roma(new_node, replication_in_host: replication_in_host)
+#    wait_join(new_node)
+#    stats = client.stats(node: new_node)
+#    assert_match(/#{new_node}/, stats['routing.nodes'])
+#    assert_not_equal(0, stats['routing.secondary'].to_i)
+#
+#    # Stop a node and generate short vnodes
+#    stop_roma_node(new_node)
+#    wait_failover(new_node)
+#    stats = client.stats
+#    assert_no_match(/#{new_node}/, stats['routing.nodes'])
+#    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
+#
+#    # Join a node with short vnodes
+#    join_roma(new_node, replication_in_host: replication_in_host)
+#    wait_join(new_node)
+#    stats = client.stats(node: new_node)
+#    assert_match(/#{new_node}/, stats['routing.nodes'])
+#    assert_not_equal(0, stats['routing.secondary'].to_i)
+   end
+
+#  def test_routing_logic_join_when_num_of_hosts_changing
 #    replication_in_host = false
 #    same_host_node = "#{DEFAULT_HOST}_#{NEW_PORTS[0]}"
 #    other_host_node = "#{DEFAULT_IP}_#{NEW_PORTS[1]}"

--- a/test/t_routing_logic.rb
+++ b/test/t_routing_logic.rb
@@ -11,60 +11,62 @@ class RoutingLogicTest < Test::Unit::TestCase
     puts "#{e} #{$ERROR_POSITION}"
   end
 
-  @@data= {
-    'single_host' => [true, NEW_PORTS.map { |port| "#{DEFAULT_HOST}_#{port}" }],
-    'multiple_hosts' => [false, NEW_PORTS.map { |port| "#{DEFAULT_IP}_#{port}" }],
-    'multiple_hosts_include_some_hosts' => [false, ["#{DEFAULT_IP}_#{NEW_PORTS[0]}", "#{DEFAULT_HOST}_#{NEW_PORTS[1]}"]]
-  }
-
   def test_routing_logic_join
-    replication_in_host, new_nodes = @@data['single_host']
-    start_roma(div_bits: 6, replication_in_host: replication_in_host)
-    sleep 12 # Wait cluster starting, otherwise join will never finish
-    client = get_client
+    data= {
+      'single_host' => [true, NEW_PORTS.map { |port| "#{DEFAULT_HOST}_#{port}" }],
+      'multiple_hosts' => [false, NEW_PORTS.map { |port| "#{DEFAULT_IP}_#{port}" }],
+      'multiple_hosts_include_some_hosts' => [false, ["#{DEFAULT_IP}_#{NEW_PORTS[0]}", "#{DEFAULT_HOST}_#{NEW_PORTS[1]}"]]
+    }
+    data.values.each{|replication_in_host, new_nodes|
+      start_roma(div_bits: 6, replication_in_host: replication_in_host)
+      sleep 12 # Wait cluster starting, otherwise join will never finish
+      client = get_client
 
-   # Join nodes
-    assert_equal(DEFAULT_NODES.size, client.rttable.nodes.size)
-    new_nodes.each do |new_node|
+      # Join nodes
+      assert_equal(DEFAULT_NODES.size, client.rttable.nodes.size)
+      new_nodes.each do |new_node|
+        join_roma(new_node, replication_in_host: replication_in_host)
+        wait_join(new_node)
+        stats = client.stats(node: new_node)
+        assert_match(/#{new_node}/, stats['routing.nodes'])
+        assert_not_equal(0, stats['routing.secondary'].to_i)
+      end
+
+      new_node = new_nodes.last
+
+      # Release and stop a node
+      release_roma_node(new_node)
+      wait_release(new_node)
+      stop_roma_node(new_node)
+      wait_failover(new_node)
+      stats = client.stats
+      assert_no_match(/#{new_node}/, stats['routing.nodes'])
+      assert_equal(0, stats['routing.short_vnodes'].to_i)
+
+      # Join a node without short vnodes
       join_roma(new_node, replication_in_host: replication_in_host)
       wait_join(new_node)
       stats = client.stats(node: new_node)
       assert_match(/#{new_node}/, stats['routing.nodes'])
       assert_not_equal(0, stats['routing.secondary'].to_i)
-    end
 
-    new_node = new_nodes.last
+      # Stop a node and generate short vnodes
+      stop_roma_node(new_node)
+      wait_failover(new_node)
+      stats = client.stats
+      assert_no_match(/#{new_node}/, stats['routing.nodes'])
+      assert_not_equal(0, stats['routing.short_vnodes'].to_i)
 
-    # Release and stop a node
-    release_roma_node(new_node)
-    wait_release(new_node)
-    stop_roma_node(new_node)
-    wait_failover(new_node)
-    stats = client.stats
-    assert_no_match(/#{new_node}/, stats['routing.nodes'])
-    assert_equal(0, stats['routing.short_vnodes'].to_i)
+      # Join a node with short vnodes
+      join_roma(new_node, replication_in_host: replication_in_host)
+      wait_join(new_node)
+      stats = client.stats(node: new_node)
+      assert_match(/#{new_node}/, stats['routing.nodes'])
+      assert_not_equal(0, stats['routing.secondary'].to_i)
 
-    # Join a node without short vnodes
-    join_roma(new_node, replication_in_host: replication_in_host)
-    wait_join(new_node)
-    stats = client.stats(node: new_node)
-    assert_match(/#{new_node}/, stats['routing.nodes'])
-    assert_not_equal(0, stats['routing.secondary'].to_i)
-
-    # Stop a node and generate short vnodes
-    stop_roma_node(new_node)
-    wait_failover(new_node)
-    stats = client.stats
-    assert_no_match(/#{new_node}/, stats['routing.nodes'])
-    assert_not_equal(0, stats['routing.short_vnodes'].to_i)
-
-    # Join a node with short vnodes
-    join_roma(new_node, replication_in_host: replication_in_host)
-    wait_join(new_node)
-    stats = client.stats(node: new_node)
-    assert_match(/#{new_node}/, stats['routing.nodes'])
-    assert_not_equal(0, stats['routing.secondary'].to_i)
-   end
+      stop_roma
+    }
+  end
 
   def test_routing_logic_join_when_num_of_hosts_changing
     replication_in_host = false

--- a/test/t_routing_logic.rb
+++ b/test/t_routing_logic.rb
@@ -11,7 +11,7 @@ class RoutingLogicTest < Test::Unit::TestCase
     puts "#{e} #{$ERROR_POSITION}"
   end
 
-  data(
+  data = {
   'single_host' => [
     true,
     NEW_PORTS.map { |port| "#{DEFAULT_HOST}_#{port}" }],
@@ -21,7 +21,8 @@ class RoutingLogicTest < Test::Unit::TestCase
   'multiple_hosts_include_some_hosts' => [
     false,
     ["#{DEFAULT_IP}_#{NEW_PORTS[0]}", "#{DEFAULT_HOST}_#{NEW_PORTS[1]}"]]
-  )
+  }
+
   def test_join(data)
     replication_in_host, new_nodes = data
     start_roma(div_bits: 6, replication_in_host: replication_in_host)


### PR DESCRIPTION
current unit test use test driven method of test-unit gem,
but some env can not this method.
So I convert basic logic.

    Finished tests in 1116.557786s, 0.3556 tests/s, 9430.8652 assertions/s.
    
    397 tests, 10530106 assertions, 0 failures, 0 errors, 0 skips
    
    ruby -v: ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-linux]