### PR TITLE
Cluster_Replication

### DIFF
--- a/lib/roma/async_process.rb
+++ b/lib/roma/async_process.rb
@@ -1065,6 +1065,7 @@ module Roma
 
       @storages.each_key do |hname|
         @rttable.v_idx.each_key do |vn|
+          raise unless $roma.cr_writer.run_existing_data_replication
           args[0].v_idx[vn].each do |replica_nid|
             res = push_a_vnode_stream(hname, vn, replica_nid)
             if res != 'STORED'

--- a/lib/roma/async_process.rb
+++ b/lib/roma/async_process.rb
@@ -1049,10 +1049,12 @@ module Roma
       @log.debug("#{__method__} #{args}")
       t = Thread.new do
         begin
+          $roma.cr_writer.run_existing_data_replication = true
           replicate_existing_data_process(args)
         rescue => e
           @log.error("#{__method__}:#{e.inspect} #{$ERROR_POSITION}")
         ensure
+          $roma.cr_writer.run_existing_data_replication = false
         end
       end
       t[:name] = __method__

--- a/lib/roma/async_process.rb
+++ b/lib/roma/async_process.rb
@@ -1046,7 +1046,6 @@ module Roma
 
     def asyncev_start_replicate_existing_data_process(args)
       # args is [$roma.cr_writer.replica_rttable])
-      @log.debug("#{__method__} #{args}")
       t = Thread.new do
         begin
           $roma.cr_writer.run_existing_data_replication = true
@@ -1061,7 +1060,7 @@ module Roma
     end
 
     def replicate_existing_data_process(args)
-      @log.info("#{__method__} #{args} :start.")
+      @log.info("#{__method__} :start.")
 
       @storages.each_key do |hname|
         @rttable.v_idx.each_key do |vn|

--- a/lib/roma/async_process.rb
+++ b/lib/roma/async_process.rb
@@ -670,7 +670,7 @@ module Roma
         con.write(data)
         sleep @stats.stream_copy_wait_param
       end
-      con.write("\0" * 20) # end of steram
+      con.write("\0" * 20) # end of stream
 
       res = con.gets # STORED\r\n or error string
       Roma::Messaging::ConPool.instance.return_connection(nid, con)
@@ -1043,5 +1043,38 @@ module Roma
 
       get_point(f, target_time, type, latency_time, new_pos, target_pos)
     end
+
+    def asyncev_start_replicate_existing_data_process(args)
+      @log.debug("#{__method__} #{args}")
+      t = Thread.new do
+        begin
+          replicate_existing_data_process(args)
+        rescue => e
+          @log.error("#{__method__}:#{e.inspect} #{$ERROR_POSITION}")
+        ensure
+        end
+      end
+      t[:name] = __method__
+    end
+
+    def replicate_existing_data_process(args)
+      @log.info("#{__method__} #{args} :start.")
+
+      replica_nid = args[0]
+      @storages.each_key do |hname|
+        @rttable.v_idx.each_key do |vn|
+          res = push_a_vnode_stream(hname, vn, replica_nid)
+          if res != 'STORED'
+            @log.error("#{__method__}:push_a_vnode was failed:hname=#{hname} vn=#{vn}:#{res}")
+            return false
+          end
+        end
+      end
+
+      @log.info("#{__method__} has done.")
+    rescue => e
+      @log.error("#{e}\n#{$ERROR_POSITION}")
+    end
+
   end # module AsyncProcess
 end # module Roma

--- a/lib/roma/async_process.rb
+++ b/lib/roma/async_process.rb
@@ -1045,6 +1045,7 @@ module Roma
     end
 
     def asyncev_start_replicate_existing_data_process(args)
+      # args is [$roma.cr_writer.replica_rttable])
       @log.debug("#{__method__} #{args}")
       t = Thread.new do
         begin
@@ -1060,13 +1061,14 @@ module Roma
     def replicate_existing_data_process(args)
       @log.info("#{__method__} #{args} :start.")
 
-      replica_nid = args[0]
       @storages.each_key do |hname|
         @rttable.v_idx.each_key do |vn|
-          res = push_a_vnode_stream(hname, vn, replica_nid)
-          if res != 'STORED'
-            @log.error("#{__method__}:push_a_vnode was failed:hname=#{hname} vn=#{vn}:#{res}")
-            return false
+          args[0].v_idx[vn].each do |replica_nid|
+            res = push_a_vnode_stream(hname, vn, replica_nid)
+            if res != 'STORED'
+              @log.error("#{__method__}:push_a_vnode was failed:hname=#{hname} vn=#{vn}:#{res}")
+              return false
+            end
           end
         end
       end

--- a/lib/roma/async_process.rb
+++ b/lib/roma/async_process.rb
@@ -643,7 +643,7 @@ module Roma
     end
 
     def push_a_vnode_stream(hname, vn, nid)
-      @log.info("#{__method__}:hname=#{hname} vn=#{vn} nid=#{nid}")
+      @log.debug("#{__method__}:hname=#{hname} vn=#{vn} nid=#{nid}")
 
       stop_clean_up
 

--- a/lib/roma/command/sys_command_receiver.rb
+++ b/lib/roma/command/sys_command_receiver.rb
@@ -229,10 +229,10 @@ module Roma
       # switch_replication <true|false> [nid]
       def ev_switch_replication(s)
         unless s.length.between?(2, 3)
-          return send_data("CLIENT_ERROR number of arguments\n\r")
+          return send_data("CLIENT_ERROR number of arguments\r\n")
         end
         unless s[1] =~ /^(true|false)$/
-          return send_data("CLIENT_ERROR value must be true or false\n\r")
+          return send_data("CLIENT_ERROR value must be true or false\r\n")
         end
 
         res = broadcast_cmd("rswitch_replication #{s[1]} #{s[2]}\r\n")

--- a/lib/roma/command/sys_command_receiver.rb
+++ b/lib/roma/command/sys_command_receiver.rb
@@ -226,7 +226,7 @@ module Roma
 
       # switch_replication command is change status of cluster replication
       # if you want to activate, assign 1 nid(addr_port) of replication cluster as argument.
-      # if you want to copy exising data, add the 'all' after nid as argument
+      # if you want to copy existing data, add the 'all' after nid as argument
       # switch_replication <true|false> [nid] [copy target]
       def ev_switch_replication(s)
         unless s.length.between?(2, 4)
@@ -248,13 +248,18 @@ module Roma
             $roma.cr_writer.update_nodelist(s[2])
             $roma.cr_writer.update_rttable(s[2])
             $roma.cr_writer.run_replication = true
-            Roma::AsyncProcess::queue.push(Roma::AsyncMessage.new('start_replicate_existing_data_process', [$roma.cr_writer.replica_rttable])) if s[3] == 'all'
+            if s[3] == 'all'
+              $roma.cr_writer.run_existing_data_replication = true
+              Roma::AsyncProcess::queue.push(Roma::AsyncMessage.new('start_replicate_existing_data_process', [$roma.cr_writer.replica_rttable]))
+            end
             res[@stats.ap_str] = "ACTIVATED"
           when 'false'
             $roma.cr_writer.replica_mklhash = nil
             $roma.cr_writer.replica_nodelist = []
             $roma.cr_writer.replica_rttable = nil
             $roma.cr_writer.run_replication = false
+            $roma.cr_writer.run_existing_data_replication = false
+            # toDO stop asynch
             res[@stats.ap_str] = "DEACTIVATED"
           end
         }
@@ -282,13 +287,17 @@ module Roma
             $roma.cr_writer.update_nodelist(s[2])
             $roma.cr_writer.update_rttable(s[2])
             $roma.cr_writer.run_replication = true
-            Roma::AsyncProcess::queue.push(Roma::AsyncMessage.new('start_replicate_existing_data_process', [$roma.cr_writer.replica_rttable])) if s[3] == 'all'
+            if s[3] == 'all'
+              $roma.cr_writer.run_existing_data_replication = true
+              Roma::AsyncProcess::queue.push(Roma::AsyncMessage.new('start_replicate_existing_data_process', [$roma.cr_writer.replica_rttable]))
+            end
             send_data("ACTIVATED\r\n")
           when 'false'
             $roma.cr_writer.replica_mklhash = nil
             $roma.cr_writer.replica_nodelist = []
             $roma.cr_writer.replica_rttable = nil
             $roma.cr_writer.run_replication = false
+            $roma.cr_writer.run_existing_data_replication = false
             send_data("DEACTIVATED\r\n")
           end
         }

--- a/lib/roma/command/sys_command_receiver.rb
+++ b/lib/roma/command/sys_command_receiver.rb
@@ -244,6 +244,7 @@ module Roma
             $roma.cr_writer.update_nodelist(s[2])
             $roma.cr_writer.update_rttable(s[2])
             $roma.cr_writer.run_replication = true
+            Roma::AsyncProcess::queue.push(Roma::AsyncMessage.new('start_replicate_existing_data_process', [s[2]]))
             res[@stats.ap_str] = "ACTIVATED"
           when 'false'
             $roma.cr_writer.replica_mklhash = nil
@@ -274,6 +275,7 @@ module Roma
             $roma.cr_writer.update_nodelist(s[2])
             $roma.cr_writer.update_rttable(s[2])
             $roma.cr_writer.run_replication = true
+            Roma::AsyncProcess::queue.push(Roma::AsyncMessage.new('start_replicate_existing_data_process', [s[2]]))
             send_data("ACTIVATED\r\n")
           when 'false'
             $roma.cr_writer.replica_mklhash = nil

--- a/lib/roma/command/sys_command_receiver.rb
+++ b/lib/roma/command/sys_command_receiver.rb
@@ -244,7 +244,7 @@ module Roma
             $roma.cr_writer.update_nodelist(s[2])
             $roma.cr_writer.update_rttable(s[2])
             $roma.cr_writer.run_replication = true
-            Roma::AsyncProcess::queue.push(Roma::AsyncMessage.new('start_replicate_existing_data_process', [s[2]]))
+            Roma::AsyncProcess::queue.push(Roma::AsyncMessage.new('start_replicate_existing_data_process', [$roma.cr_writer.replica_rttable]))
             res[@stats.ap_str] = "ACTIVATED"
           when 'false'
             $roma.cr_writer.replica_mklhash = nil
@@ -275,7 +275,7 @@ module Roma
             $roma.cr_writer.update_nodelist(s[2])
             $roma.cr_writer.update_rttable(s[2])
             $roma.cr_writer.run_replication = true
-            Roma::AsyncProcess::queue.push(Roma::AsyncMessage.new('start_replicate_existing_data_process', [s[2]]))
+            Roma::AsyncProcess::queue.push(Roma::AsyncMessage.new('start_replicate_existing_data_process', [$roma.cr_writer.replica_rttable]))
             send_data("ACTIVATED\r\n")
           when 'false'
             $roma.cr_writer.replica_mklhash = nil

--- a/lib/roma/command/sys_command_receiver.rb
+++ b/lib/roma/command/sys_command_receiver.rb
@@ -259,7 +259,6 @@ module Roma
             $roma.cr_writer.replica_rttable = nil
             $roma.cr_writer.run_replication = false
             $roma.cr_writer.run_existing_data_replication = false
-            # toDO stop asynch
             res[@stats.ap_str] = "DEACTIVATED"
           end
         }

--- a/lib/roma/command/sys_command_receiver.rb
+++ b/lib/roma/command/sys_command_receiver.rb
@@ -239,7 +239,7 @@ module Roma
           return send_data("CLIENT_ERROR [copy target] must be all or nil\r\n")
         end
 
-        res = broadcast_cmd("rswitch_replication #{s[1]} #{s[2]}\r\n")
+        res = broadcast_cmd("rswitch_replication #{s[1]} #{s[2]} #{s[3]}\r\n")
 
         timeout(1){
           case s[1]

--- a/lib/roma/command/vn_command_receiver.rb
+++ b/lib/roma/command/vn_command_receiver.rb
@@ -6,7 +6,7 @@ module Roma
 
     module VnodeCommandReceiver
 
-      # spushv <true/false>
+      # spushv_protection <true/false>
       def ev_spushv_protection(s)
         if s.length == 1
           send_data("#{@stats.spushv_protection}\r\n")

--- a/lib/roma/plugin/plugin_storage.rb
+++ b/lib/roma/plugin/plugin_storage.rb
@@ -156,11 +156,6 @@ module Roma
         if @stats.wb_command_map.key?(:delete)
           Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[:delete], key, res[4])
         end
-        if $roma.cr_writer.run_replication
-          k = k+hname  if hname != @defhash
-          fnc = 'delete'
-          Roma::ClusterReplicationProcess::push("#{fnc} #{key}\r\n", key)
-        end
 
         nodes[1..-1].each{ |nid|
           res2 = send_cmd(nid,"rdelete #{key}\e#{hname} #{res[2]}\r\n")
@@ -170,6 +165,13 @@ module Roma
           end
         }
         return send_data("NOT_FOUND\r\n") unless res[4]
+
+        if $roma.cr_writer.run_replication
+          k = k+hname  if hname != @defhash
+          fnc = 'delete'
+          Roma::ClusterReplicationProcess::push("#{fnc} #{key}\r\n", key)
+        end
+
         send_data("DELETED\r\n")
       end
 
@@ -203,11 +205,6 @@ module Roma
         if @stats.wb_command_map.key?(:delete)
           Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[:delete], key, res[4])
         end
-        if $roma.cr_writer.run_replication
-          k = k+hname  if hname != @defhash
-          fnc = 'delete'
-          Roma::ClusterReplicationProcess::push("#{fnc} #{key}\r\n", key)
-        end
 
         nodes.delete(@nid)
         nodes.each{ |nid|
@@ -218,6 +215,13 @@ module Roma
           end
         }
         return send_data("NOT_FOUND\r\n") unless res[4]
+
+        if $roma.cr_writer.run_replication
+          k = k+hname  if hname != @defhash
+          fnc = 'delete'
+          Roma::ClusterReplicationProcess::push("#{fnc} #{key}\r\n", key)
+        end
+
         send_data("DELETED\r\n")
       end
 
@@ -348,12 +352,12 @@ module Roma
 @log.debug(":set_export")
             Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[:set_expt], key, expt.to_s)
           end
+          redundant(nodes[1..-1], hname, key, d, ret[2], ret[3], ret[4])
           if $roma.cr_writer.run_replication
             k = k+hname  if hname != @defhash
             fnc = 'set_expt'
             Roma::ClusterReplicationProcess::push("#{fnc} #{key} #{expt}\r\n", key, expt)
           end
-          redundant(nodes[1..-1], hname, key, d, ret[2], ret[3], ret[4])
           send_data("STORED\r\n")
         else
           return send_data("NOT_STORED\r\n")
@@ -390,12 +394,12 @@ module Roma
           if @stats.wb_command_map.key?(:set_expt)
             Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[:set_expt], key, expt.to_s)
           end
+          redundant(nodes[1..-1], hname, key, d, ret[2], ret[3], ret[4])
           if $roma.cr_writer.run_replication
             k = k+hname  if hname != @defhash
             fnc = 'set_expt'
             Roma::ClusterReplicationProcess::push("#{fnc} #{key} #{expt}\r\n", key, expt)
           end
-          redundant(nodes[1..-1], hname, key, d, ret[2], ret[3], ret[4])
           send_data("STORED\r\n")
         else
           return send_data("NOT_STORED\r\n")
@@ -490,11 +494,11 @@ module Roma
           if @stats.wb_command_map.key?(fnc)
             Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[fnc], k, ret[4])
           end
+          redundant(nodes, hname, k, d, ret[2], expt, ret[4])
           if $roma.cr_writer.run_replication
             k = k+hname  if hname != @defhash
             Roma::ClusterReplicationProcess::push("#{fnc} #{k} 0 #{expt} #{v.length} \r\n#{v}\r\n", k, v)
           end
-          redundant(nodes, hname, k, d, ret[2], expt, ret[4])
           send_data("STORED\r\n")
         else
           @log.error("#{fnc} NOT_STORED:#{hname} #{vn} #{k} #{d} #{expt}")

--- a/lib/roma/plugin/plugin_storage.rb
+++ b/lib/roma/plugin/plugin_storage.rb
@@ -470,6 +470,10 @@ module Roma
           if @stats.wb_command_map.key?(fnc)
             Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[fnc], k, ret[4])
           end
+          if $roma.cr_writer.run_replication
+            Roma::ClusterReplicationProcess::push("#{fnc} #{k} 0 #{expt} #{v.length} \r\n#{v}\r\n", k, v)
+            #Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[fnc], k, ret[4])
+          end
           redundant(nodes, hname, k, d, ret[2], expt, ret[4])
           send_data("STORED\r\n")
         else

--- a/lib/roma/plugin/plugin_storage.rb
+++ b/lib/roma/plugin/plugin_storage.rb
@@ -169,7 +169,7 @@ module Roma
         if $roma.cr_writer.run_replication
           k = k+hname  if hname != @defhash
           fnc = 'delete'
-          Roma::ClusterReplicationProcess::push("#{fnc} #{key}\r\n", key)
+          Roma::WriteBehindProcess::push(nil, "#{fnc} #{key}\r\n", key, nil)
         end
 
         send_data("DELETED\r\n")
@@ -219,7 +219,7 @@ module Roma
         if $roma.cr_writer.run_replication
           k = k+hname  if hname != @defhash
           fnc = 'delete'
-          Roma::ClusterReplicationProcess::push("#{fnc} #{key}\r\n", key)
+          Roma::WriteBehindProcess::push(nil, "#{fnc} #{key}\r\n", key, nil)
         end
 
         send_data("DELETED\r\n")
@@ -356,7 +356,7 @@ module Roma
           if $roma.cr_writer.run_replication
             k = k+hname  if hname != @defhash
             fnc = 'set_expt'
-            Roma::ClusterReplicationProcess::push("#{fnc} #{key} #{expt}\r\n", key, expt)
+            Roma::WriteBehindProcess::push(nil, "#{fnc} #{key} #{expt}\r\n", key, expt)
           end
           send_data("STORED\r\n")
         else
@@ -398,7 +398,7 @@ module Roma
           if $roma.cr_writer.run_replication
             k = k+hname  if hname != @defhash
             fnc = 'set_expt'
-            Roma::ClusterReplicationProcess::push("#{fnc} #{key} #{expt}\r\n", key, expt)
+            Roma::WriteBehindProcess::push(nil, "#{fnc} #{key} #{expt}\r\n", key, expt)
           end
           send_data("STORED\r\n")
         else
@@ -497,7 +497,7 @@ module Roma
           redundant(nodes, hname, k, d, ret[2], expt, ret[4])
           if $roma.cr_writer.run_replication
             k = k+hname  if hname != @defhash
-            Roma::ClusterReplicationProcess::push("#{fnc} #{k} 0 #{expt} #{v.length} \r\n#{v}\r\n", k, v)
+            Roma::WriteBehindProcess::push(nil, "#{fnc} #{k} 1 #{expt} #{v.length} \r\n#{v}\r\n", k, v)
           end
           send_data("STORED\r\n")
         else
@@ -536,7 +536,7 @@ module Roma
           if $roma.cr_writer.run_replication
             k = k+hname  if hname != @defhash
             fnc = 'set' # To restrain a defference between main and replica cluster due to clk 
-            Roma::ClusterReplicationProcess::push("#{fnc} #{k} 0 #{expt} #{v.length} \r\n#{v}\r\n", k, v)
+            Roma::WriteBehindProcess::push(nil, "#{fnc} #{k} 0 #{expt} #{v.length} \r\n#{v}\r\n", k, v)
           end
           redundant(nodes, hname, k, d, ret[2], expt, ret[4])
           send_data("STORED\r\n")          
@@ -638,7 +638,7 @@ module Roma
           end
           if $roma.cr_writer.run_replication
             k = k+hname  if hname != @defhash
-            Roma::ClusterReplicationProcess::push("#{fnc} #{k} #{v}\r\n", k, v)
+            Roma::WriteBehindProcess::push(nil, "#{fnc} #{k} #{v}\r\n", k, v)
           end
           redundant(nodes, hname, k, d, res[2], res[3], res[4])
           send_data("#{res[4]}\r\n")

--- a/lib/roma/plugin/plugin_storage.rb
+++ b/lib/roma/plugin/plugin_storage.rb
@@ -491,8 +491,6 @@ module Roma
             Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[fnc], k, ret[4])
           end
           if $roma.cr_writer.run_replication
-            ##Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[fnc], k, ret[4])
-            #Roma::ClusterReplicationProcess::push("#{fnc} #{k} 0 #{expt} #{v.length} \r\n#{v}\r\n", k, v)
             k = k+hname  if hname != @defhash
             Roma::ClusterReplicationProcess::push("#{fnc} #{k} 0 #{expt} #{v.length} \r\n#{v}\r\n", k, v)
           end

--- a/lib/roma/plugin/plugin_storage.rb
+++ b/lib/roma/plugin/plugin_storage.rb
@@ -348,6 +348,11 @@ module Roma
 @log.debug(":set_export")
             Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[:set_expt], key, expt.to_s)
           end
+          if $roma.cr_writer.run_replication
+            k = k+hname  if hname != @defhash
+            fnc = 'set_expt'
+            Roma::ClusterReplicationProcess::push("#{fnc} #{key} #{expt}\r\n", key, expt)
+          end
           redundant(nodes[1..-1], hname, key, d, ret[2], ret[3], ret[4])
           send_data("STORED\r\n")
         else
@@ -384,6 +389,11 @@ module Roma
         if ret
           if @stats.wb_command_map.key?(:set_expt)
             Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[:set_expt], key, expt.to_s)
+          end
+          if $roma.cr_writer.run_replication
+            k = k+hname  if hname != @defhash
+            fnc = 'set_expt'
+            Roma::ClusterReplicationProcess::push("#{fnc} #{key} #{expt}\r\n", key, expt)
           end
           redundant(nodes[1..-1], hname, key, d, ret[2], ret[3], ret[4])
           send_data("STORED\r\n")

--- a/lib/roma/plugin/plugin_storage.rb
+++ b/lib/roma/plugin/plugin_storage.rb
@@ -167,9 +167,9 @@ module Roma
         return send_data("NOT_FOUND\r\n") unless res[4]
 
         if $roma.cr_writer.run_replication
-          k = k+hname  if hname != @defhash
+          k = "#{key}\e#{hname}" if hname != @defhash
           fnc = 'delete'
-          Roma::WriteBehindProcess::push(nil, "#{fnc} #{key}\r\n", key, nil)
+          Roma::WriteBehindProcess::push(nil, "#{fnc} #{k}\r\n", k, nil)
         end
 
         send_data("DELETED\r\n")
@@ -217,9 +217,9 @@ module Roma
         return send_data("NOT_FOUND\r\n") unless res[4]
 
         if $roma.cr_writer.run_replication
-          k = k+hname  if hname != @defhash
+          k = "#{key}\e#{hname}" if hname != @defhash
           fnc = 'delete'
-          Roma::WriteBehindProcess::push(nil, "#{fnc} #{key}\r\n", key, nil)
+          Roma::WriteBehindProcess::push(nil, "#{fnc} #{k}\r\n", k, nil)
         end
 
         send_data("DELETED\r\n")
@@ -354,9 +354,9 @@ module Roma
           end
           redundant(nodes[1..-1], hname, key, d, ret[2], ret[3], ret[4])
           if $roma.cr_writer.run_replication
-            k = k+hname  if hname != @defhash
+            k = "#{key}\e#{hname}" if hname != @defhash
             fnc = 'set_expt'
-            Roma::WriteBehindProcess::push(nil, "#{fnc} #{key} #{expt}\r\n", key, expt)
+            Roma::WriteBehindProcess::push(nil, "#{fnc} #{k} #{expt}\r\n", k, expt)
           end
           send_data("STORED\r\n")
         else
@@ -396,9 +396,9 @@ module Roma
           end
           redundant(nodes[1..-1], hname, key, d, ret[2], ret[3], ret[4])
           if $roma.cr_writer.run_replication
-            k = k+hname  if hname != @defhash
+            k = "#{key}\e#{hname}" if hname != @defhash
             fnc = 'set_expt'
-            Roma::WriteBehindProcess::push(nil, "#{fnc} #{key} #{expt}\r\n", key, expt)
+            Roma::WriteBehindProcess::push(nil, "#{fnc} #{k} #{expt}\r\n", k, expt)
           end
           send_data("STORED\r\n")
         else
@@ -496,7 +496,7 @@ module Roma
           end
           redundant(nodes, hname, k, d, ret[2], expt, ret[4])
           if $roma.cr_writer.run_replication
-            k = k+hname  if hname != @defhash
+            k = "#{k}\e#{hname}" if hname != @defhash
             Roma::WriteBehindProcess::push(nil, "#{fnc} #{k} 1 #{expt} #{v.length} \r\n#{v}\r\n", k, v)
           end
           send_data("STORED\r\n")
@@ -534,7 +534,7 @@ module Roma
             Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[:cas], k, ret[4])
           end
           if $roma.cr_writer.run_replication
-            k = k+hname  if hname != @defhash
+            k = "#{k}\e#{hname}" if hname != @defhash
             fnc = 'set' # To restrain a defference between main and replica cluster due to clk 
             Roma::WriteBehindProcess::push(nil, "#{fnc} #{k} 0 #{expt} #{v.length} \r\n#{v}\r\n", k, v)
           end
@@ -637,7 +637,7 @@ module Roma
             Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[fnc], k, res[4])
           end
           if $roma.cr_writer.run_replication
-            k = k+hname  if hname != @defhash
+            k = "#{k}\e#{hname}" if hname != @defhash
             Roma::WriteBehindProcess::push(nil, "#{fnc} #{k} #{v}\r\n", k, v)
           end
           redundant(nodes, hname, k, d, res[2], res[3], res[4])

--- a/lib/roma/plugin/plugin_storage.rb
+++ b/lib/roma/plugin/plugin_storage.rb
@@ -471,8 +471,10 @@ module Roma
             Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[fnc], k, ret[4])
           end
           if $roma.cr_writer.run_replication
+            ##Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[fnc], k, ret[4])
+            #Roma::ClusterReplicationProcess::push("#{fnc} #{k} 0 #{expt} #{v.length} \r\n#{v}\r\n", k, v)
+            k = k+hname  if hname != @defhash
             Roma::ClusterReplicationProcess::push("#{fnc} #{k} 0 #{expt} #{v.length} \r\n#{v}\r\n", k, v)
-            #Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[fnc], k, ret[4])
           end
           redundant(nodes, hname, k, d, ret[2], expt, ret[4])
           send_data("STORED\r\n")

--- a/lib/roma/plugin/plugin_storage.rb
+++ b/lib/roma/plugin/plugin_storage.rb
@@ -126,6 +126,7 @@ module Roma
         d = Digest::SHA1.hexdigest(key).hex % @rttable.hbits
         vn = @rttable.get_vnode_id(d)
         nodes = @rttable.search_nodes_for_write(vn)
+
         if nodes[0] != @nid
           cmd = "fdelete #{key}\e#{hname}"
           s[2..-1].each{|c| cmd << " #{c}"}
@@ -137,6 +138,7 @@ module Roma
           end
           return send_data("#{res}\r\n")
         end
+
         unless @storages.key?(hname)
           send_data("SERVER_ERROR #{hname} does not exists.\r\n")
           return
@@ -167,9 +169,8 @@ module Roma
         return send_data("NOT_FOUND\r\n") unless res[4]
 
         if $roma.cr_writer.run_replication
-          k = "#{key}\e#{hname}" if hname != @defhash
           fnc = 'delete'
-          Roma::WriteBehindProcess::push(nil, "#{fnc} #{k}\r\n", k, nil)
+          Roma::WriteBehindProcess::push(nil, "#{fnc} #{s[1]}\r\n", s[1], nil)
         end
 
         send_data("DELETED\r\n")
@@ -217,9 +218,8 @@ module Roma
         return send_data("NOT_FOUND\r\n") unless res[4]
 
         if $roma.cr_writer.run_replication
-          k = "#{key}\e#{hname}" if hname != @defhash
           fnc = 'delete'
-          Roma::WriteBehindProcess::push(nil, "#{fnc} #{k}\r\n", k, nil)
+          Roma::WriteBehindProcess::push(nil, "#{fnc} #{s[1]}\r\n", s[1], nil)
         end
 
         send_data("DELETED\r\n")
@@ -354,9 +354,8 @@ module Roma
           end
           redundant(nodes[1..-1], hname, key, d, ret[2], ret[3], ret[4])
           if $roma.cr_writer.run_replication
-            k = "#{key}\e#{hname}" if hname != @defhash
             fnc = 'set_expt'
-            Roma::WriteBehindProcess::push(nil, "#{fnc} #{k} #{expt}\r\n", k, expt)
+            Roma::WriteBehindProcess::push(nil, "#{fnc} #{s[1]} #{expt}\r\n", s[1], expt)
           end
           send_data("STORED\r\n")
         else
@@ -396,9 +395,8 @@ module Roma
           end
           redundant(nodes[1..-1], hname, key, d, ret[2], ret[3], ret[4])
           if $roma.cr_writer.run_replication
-            k = "#{key}\e#{hname}" if hname != @defhash
             fnc = 'set_expt'
-            Roma::WriteBehindProcess::push(nil, "#{fnc} #{k} #{expt}\r\n", k, expt)
+            Roma::WriteBehindProcess::push(nil, "#{fnc} #{s[1]} #{expt}\r\n", s[1], expt)
           end
           send_data("STORED\r\n")
         else

--- a/lib/roma/plugin/plugin_storage.rb
+++ b/lib/roma/plugin/plugin_storage.rb
@@ -156,6 +156,11 @@ module Roma
         if @stats.wb_command_map.key?(:delete)
           Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[:delete], key, res[4])
         end
+        if $roma.cr_writer.run_replication
+          k = k+hname  if hname != @defhash
+          fnc = 'delete'
+          Roma::ClusterReplicationProcess::push("#{fnc} #{key}\r\n", key)
+        end
 
         nodes[1..-1].each{ |nid|
           res2 = send_cmd(nid,"rdelete #{key}\e#{hname} #{res[2]}\r\n")
@@ -197,6 +202,11 @@ module Roma
 
         if @stats.wb_command_map.key?(:delete)
           Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[:delete], key, res[4])
+        end
+        if $roma.cr_writer.run_replication
+          k = k+hname  if hname != @defhash
+          fnc = 'delete'
+          Roma::ClusterReplicationProcess::push("#{fnc} #{key}\r\n", key)
         end
 
         nodes.delete(@nid)

--- a/lib/roma/plugin/plugin_storage.rb
+++ b/lib/roma/plugin/plugin_storage.rb
@@ -531,8 +531,8 @@ module Roma
           end
           if $roma.cr_writer.run_replication
             k = k+hname  if hname != @defhash
-            fnc = 'cas'
-            Roma::ClusterReplicationProcess::push("#{fnc} #{k} 0 #{expt} #{v.length} #{clk}\r\n#{v}\r\n", k, v)
+            fnc = 'set' # To restrain a defference between main and replica cluster due to clk 
+            Roma::ClusterReplicationProcess::push("#{fnc} #{k} 0 #{expt} #{v.length} \r\n#{v}\r\n", k, v)
           end
           redundant(nodes, hname, k, d, ret[2], expt, ret[4])
           send_data("STORED\r\n")          

--- a/lib/roma/plugin/plugin_storage.rb
+++ b/lib/roma/plugin/plugin_storage.rb
@@ -531,6 +531,11 @@ module Roma
           if @stats.wb_command_map.key?(:cas)
             Roma::WriteBehindProcess::push(hname, @stats.wb_command_map[:cas], k, ret[4])
           end
+          if $roma.cr_writer.run_replication
+            k = k+hname  if hname != @defhash
+            fnc = 'cas'
+            Roma::ClusterReplicationProcess::push("#{fnc} #{k} 0 #{expt} #{v.length} #{clk}\r\n#{v}\r\n", k, v)
+          end
           redundant(nodes, hname, k, d, ret[2], expt, ret[4])
           send_data("STORED\r\n")          
         end

--- a/lib/roma/romad.rb
+++ b/lib/roma/romad.rb
@@ -17,7 +17,6 @@ module Roma
   class Romad
     include AsyncProcess
     include WriteBehindProcess
-    include ClusterReplicationProcess
 
     attr :storages
     attr :rttable
@@ -74,7 +73,6 @@ module Roma
 
       start_async_process
       start_wb_process
-      start_cr_process
       timer
 
       if @stats.join_ap
@@ -156,7 +154,6 @@ module Roma
       end
       stop_async_process
       stop_wb_process
-      stop_cr_process
       stop
     end
 

--- a/lib/roma/romad.rb
+++ b/lib/roma/romad.rb
@@ -22,6 +22,7 @@ module Roma
     attr :rttable
     attr :stats
     attr :wb_writer
+    attr :cr_writer
 
     attr_accessor :eventloop
     attr_accessor :startup
@@ -229,6 +230,8 @@ module Roma
                                                      Roma::Config::WRITEBEHIND_PATH,
                                                      Roma::Config::WRITEBEHIND_SHIFT_SIZE,
                                                      @log)
+
+      @cr_writer = Roma::WriteBehind::StreamWriter.new(@log)
     end
 
     def initialize_plugin

--- a/lib/roma/romad.rb
+++ b/lib/roma/romad.rb
@@ -605,6 +605,15 @@ module Roma
         Roma::AsyncProcess::queue.push(Roma::AsyncMessage.new('start_storage_clean_up_process'))
       end
 
+      if @cr_writer.run_replication
+        if @cr_writer.change_mklhash?
+          nid = @cr_writer.replica_nodelist.sample
+          @cr_writer.update_mklhash(nid)
+          @cr_writer.update_nodelist(nid)
+          @cr_writer.update_rttable(nid)
+        end
+      end
+
       @stats.clear_counters
     rescue Exception =>e
       @log.error("#{e}\n#{$@}")

--- a/lib/roma/romad.rb
+++ b/lib/roma/romad.rb
@@ -17,6 +17,7 @@ module Roma
   class Romad
     include AsyncProcess
     include WriteBehindProcess
+    include ClusterReplicationProcess
 
     attr :storages
     attr :rttable
@@ -73,6 +74,7 @@ module Roma
 
       start_async_process
       start_wb_process
+      start_cr_process
       timer
 
       if @stats.join_ap
@@ -154,6 +156,7 @@ module Roma
       end
       stop_async_process
       stop_wb_process
+      stop_cr_process
       stop
     end
 

--- a/lib/roma/routing/cb_rttable.rb
+++ b/lib/roma/routing/cb_rttable.rb
@@ -142,7 +142,7 @@ module Roma
         hosts.length < @rd.rn
       end
 
-      # Retuens the list of losted-data vnode newer than argument time.
+      # Returns the list of losted-data vnode newer than argument time.
       def search_lost_vnodes(t)
         ret = []
         @rd.each_log_all(@fname){|log_t,line|

--- a/lib/roma/write_behind.rb
+++ b/lib/roma/write_behind.rb
@@ -240,7 +240,7 @@ module Roma
           con = Roma::Messaging::ConPool.instance.get_connection(nid)
           con.write(cmd)
           #@log.debug("ClusterReplication: key=[#{key}] value='#{value}'")
-          res = con.gets # essential for return con of MessagingConPool
+          con.gets # for return connection
           Roma::Messaging::ConPool.instance.return_connection(nid, con)
         end
       rescue => e

--- a/lib/roma/write_behind.rb
+++ b/lib/roma/write_behind.rb
@@ -283,7 +283,6 @@ module Roma
       end
       @wb_thread.exit
       @wb_writer.close_all
-      @cr_thread.exit
       @cr_writer.close_all
     end
 

--- a/lib/roma/write_behind.rb
+++ b/lib/roma/write_behind.rb
@@ -128,6 +128,7 @@ module Roma
     class StreamWriter
 
       attr_accessor :run_replication
+      attr_accessor :run_existing_data_replication
       attr_accessor :replica_mklhash
       attr_accessor :replica_nodelist
       attr_accessor :replica_rttable
@@ -135,6 +136,7 @@ module Roma
       def initialize(log)
         @log = log
         @run_replication = false
+        @run_existing_data_replication = false
         @replica_mklhash = nil
         @replica_nodelist = []
         @replica_rttable = nil
@@ -144,6 +146,7 @@ module Roma
       def get_stat
         ret = {}
         ret['write-behind.run_replication'] = @run_replication
+        ret['write-behind.run_existing_data_replication'] = @run_existing_data_replication
         ret['write-behind.replica_mklhash'] = @replica_mklhash
         ret['write-behind.replica_nodelist'] = @replica_nodelist
         ret

--- a/lib/roma/write_behind.rb
+++ b/lib/roma/write_behind.rb
@@ -224,7 +224,7 @@ module Roma
         nil
       end
 
-      def search_replica_node(key)
+      def search_replica_primary_node(key)
         d = Digest::SHA1.hexdigest(key).hex % (2**@replica_rttable.dgst_bits)
         nodes = @replica_rttable.v_idx[d & @replica_rttable.search_mask]
         return nodes[0] # for send primary node of replica cluster
@@ -233,13 +233,12 @@ module Roma
         nil
       end
 
-      def transmit(cmd, key, value)
+      def transmit(cmd, key, value) # value is for error log
         timeout(5) do
           @do_transmit = true
-          nid = search_replica_node(key)
+          nid = search_replica_primary_node(key)
           con = Roma::Messaging::ConPool.instance.get_connection(nid)
           con.write(cmd)
-          #@log.debug("ClusterReplication: key=[#{key}] value='#{value}'")
           con.gets # for return connection
           Roma::Messaging::ConPool.instance.return_connection(nid, con)
         end

--- a/lib/roma/write_behind.rb
+++ b/lib/roma/write_behind.rb
@@ -221,22 +221,10 @@ module Roma
         nil
       end
 
-      def search_replica_vnode(key)
+      def search_replica_node(key)
         d = Digest::SHA1.hexdigest(key).hex % (2**@replica_rttable.dgst_bits)
         nodes = @replica_rttable.v_idx[d & @replica_rttable.search_mask]
-        nodes.each_index { |i|
-          return nodes[i]
-          #return [nodes[i], d] if @fail_cnt[nodes[i]] == 0
-        }
-        # for expecting an auto assign process
-        #svn = vn = d & @search_mask
-        #while( (vn = @rd.next_vnode(vn)) != svn )
-        #  nodes = @rd.v_idx[vn]
-        #  nodes.each_index { |i|
-        #    return [nodes[i], d] if @fail_cnt[nodes[i]] == 0
-        #  }
-        #end
-        #nil
+        return nodes[0] # for send primary node of replica cluster
       rescue => e
         @log.error("#{e}\n#{$@}")
         nil
@@ -245,7 +233,7 @@ module Roma
       def transmit(cmd, key, value)
         timeout(5) do
           @do_transmit = true
-          nid = search_replica_vnode(key)
+          nid = search_replica_node(key)
           con = Roma::Messaging::ConPool.instance.get_connection(nid)
           con.write(cmd)
           #@log.debug("ClusterReplication: key=[#{key}] value='#{value}'")

--- a/lib/roma/write_behind.rb
+++ b/lib/roma/write_behind.rb
@@ -240,6 +240,7 @@ module Roma
           con = Roma::Messaging::ConPool.instance.get_connection(nid)
           con.write(cmd)
           #@log.debug("ClusterReplication: key=[#{key}] value='#{value}'")
+          res = con.gets # essential for return con of MessagingConPool
           Roma::Messaging::ConPool.instance.return_connection(nid, con)
         end
       rescue => e

--- a/lib/roma/write_behind.rb
+++ b/lib/roma/write_behind.rb
@@ -328,7 +328,7 @@ module Roma
 
     @@cr_queue = Queue.new
 
-    def self.push(cmd, key, value)
+    def self.push(cmd, key, value=nil) # nil for delete command
       @@cr_queue.push([cmd, key, value])
     end
 

--- a/lib/roma/write_behind.rb
+++ b/lib/roma/write_behind.rb
@@ -146,7 +146,6 @@ module Roma
         ret['write-behind.run_replication'] = @run_replication
         ret['write-behind.replica_mklhash'] = @replica_mklhash
         ret['write-behind.replica_nodelist'] = @replica_nodelist
-        ret['write-behind.replica_rttable'] = @replica_rttable
         ret
       end
 

--- a/test/roma-test-utils.rb
+++ b/test/roma-test-utils.rb
@@ -20,7 +20,6 @@ module RomaTestUtils
   DEFAULT_PORTS = %w(11211 11212)
   DEFAULT_NODES = DEFAULT_PORTS.map { |port| "#{DEFAULT_HOST}_#{port}" }
   DEFAULT_TIMEOUT_SEC = 90
-  REPLICA_CONFIG = 'config4replica.rb'
   REPLICA_PORTS = %w(21211 21212)
   REPLICA_NODES = REPLICA_PORTS.map { |port| "#{DEFAULT_HOST}_#{port}" }
   SHELL_LOG = 'roma_test_outputs.log'

--- a/test/roma-test-utils.rb
+++ b/test/roma-test-utils.rb
@@ -20,6 +20,9 @@ module RomaTestUtils
   DEFAULT_PORTS = %w(11211 11212)
   DEFAULT_NODES = DEFAULT_PORTS.map { |port| "#{DEFAULT_HOST}_#{port}" }
   DEFAULT_TIMEOUT_SEC = 90
+  REPLICA_CONFIG = 'config4replica.rb'
+  REPLICA_PORTS = %w(21211 21212)
+  REPLICA_NODES = REPLICA_PORTS.map { |port| "#{DEFAULT_HOST}_#{port}" }
   SHELL_LOG = 'roma_test_outputs.log'
 
   Roma::Logging::RLogger.create_singleton_instance("#{Roma::Config::LOG_PATH}/roma_test.log",
@@ -37,6 +40,20 @@ module RomaTestUtils
     sleep 0.2
 
     DEFAULT_NODES.each do |node|
+      do_command_romad(node, conf, replication_in_host)
+    end
+    sleep 1
+  end
+
+  def start_roma_replica(conf = DEFAULT_CONFIG, div_bits: 3, replication_in_host: true)
+    FileUtils.rm_rf(Dir.glob("#{Roma::Config::STORAGE_PATH}/#{REPLICA_NODES[0][0..-2]}?*"))
+    FileUtils.rm_rf(Dir.glob("#{Roma::Config::STORAGE_PATH}/#{DEFAULT_IP}_#{REPLICA_PORTS[0][0..-2]}?*"))
+    sleep 0.1
+
+    system("#{ruby_path} #{mkroute_path} #{REPLICA_NODES.join(' ')} -d #{div_bits} --replication_in_host >> #{SHELL_LOG} 2>&1")
+    sleep 0.2
+
+    REPLICA_NODES.each do |node|
       do_command_romad(node, conf, replication_in_host)
     end
     sleep 1
@@ -115,6 +132,13 @@ module RomaTestUtils
   def stop_roma
     balse_message = %w(balse yes)
     send_message(messages: balse_message)
+    Roma::Client::ConPool.instance.close_all
+    Roma::Messaging::ConPool.instance.close_all
+  end
+
+  def stop_roma_replica
+    balse_message = %w(balse yes)
+    send_message(messages: balse_message, node: REPLICA_NODES[0])
     Roma::Client::ConPool.instance.close_all
     Roma::Messaging::ConPool.instance.close_all
   end

--- a/test/t_mhash.rb
+++ b/test/t_mhash.rb
@@ -99,7 +99,7 @@ class MHashTest < Test::Unit::TestCase
     assert_equal('STORED', @rc.set('roma', 'hname=test'))
     assert_equal('hname=test', @rc.get('roma'))
 
-    # stop roam
+    # stop roma
     stop_roma
 
     # restart roma

--- a/test/t_replication.rb
+++ b/test/t_replication.rb
@@ -149,31 +149,41 @@ class ClusterReplicationTest < Test::Unit::TestCase
 
     # set/get
     @rc.set('key1', 'val1')
+    sleep 0.1
     assert_equal('val1', @rc_replica.get('key1'))
 
     # add
     @rc.add('key2', 'val2')
+    sleep 0.1
     assert_equal('val2', @rc_replica.get('key2'))
     @rc.add("key2", "val3")
+    sleep 0.1
     assert_equal('val2', @rc_replica.get('key2'))
 
     # replace
     @rc.set('key3', 'val3')
+    sleep 0.1
     @rc.replace('key3', 'val4')
+    sleep 0.1
     assert_equal('val4', @rc_replica.get('key3'))
     @rc.replace('key4', 'val4')
+    sleep 0.1
     assert_nil( @rc_replica.get('key4'))
    
     # append
     @rc.set('key5','value5', 0, true)
+    sleep 0.1
     assert_equal('value5', @rc_replica.get('key5', true))
     @rc.append("key5","_end")
+    sleep 0.1
     assert_equal("value5_end", @rc_replica.get('key5',true))
 
     # prepend
     @rc.set('key6','value6', 0, true)
+    sleep 0.1
     assert_equal('value6', @rc_replica.get('key6', true))
     @rc.prepend("key6","start_")
+    sleep 0.1
     assert_equal("start_value6", @rc_replica.get('key6',true))
   end
 
@@ -182,30 +192,39 @@ class ClusterReplicationTest < Test::Unit::TestCase
 
     # delete
     @rc.set('key1', 'val1')
+    sleep 0.1
     assert_equal('val1', @rc_replica.get('key1'))
     @rc.delete('key1')
+    sleep 0.1
     assert_nil(@rc_replica.get('key1'))
 
     # incr
     @rc.set('key2','100',0,true)
+    sleep 0.1
     assert_equal('100', @rc_replica.get('key2', true))
     @rc.incr('key2')
+    sleep 0.1
     assert_equal('101', @rc_replica.get('key2', true))
     @rc.incr('key2', 10)
+    sleep 0.1
     assert_equal('111', @rc_replica.get('key2', true))
 
     # decr
     @rc.set('key3','100', 0, true)
+    sleep 0.1
     assert_equal('100', @rc_replica.get('key3', true))
 
     @rc.decr('key3')
+    sleep 0.1
     assert_equal('99', @rc_replica.get('key3', true))
 
     @rc.decr('key3', 10)
+    sleep 0.1
     assert_equal('89', @rc_replica.get('key3', true))
 
     # expt
     @rc.set('key4', 'val4', 1)
+    sleep 0.1
     assert_equal('val4', @rc_replica.get('key4'))
     sleep 2
     assert_nil( @rc_replica.get('key4') )

--- a/test/t_replication.rb
+++ b/test/t_replication.rb
@@ -205,7 +205,7 @@ class ClusterReplicationTest < Test::Unit::TestCase
     @rc.set('key2', 'val2')
     @rc.set('key3', 'val3')
 
-    send_cmd('localhost_11211', 'switch_replication true localhost_21211')
+    send_cmd('localhost_11211', 'switch_replication true localhost_21211 all')
     sleep 1
 
     assert_equal('val1', @rc_replica.get('key1'))
@@ -213,12 +213,25 @@ class ClusterReplicationTest < Test::Unit::TestCase
     assert_equal('val3', @rc_replica.get('key3'))
   end
 
+  def test_rc_background_copy_not_copy
+    @rc.set('key1', 'val1')
+    @rc.set('key2', 'val2')
+    @rc.set('key3', 'val3')
+
+    send_cmd('localhost_11211', 'switch_replication true localhost_21211')
+    sleep 1
+
+    assert_nil(@rc_replica.get('key1'))
+    assert_nil(@rc_replica.get('key2'))
+    assert_nil(@rc_replica.get('key3'))
+  end
+
   def test_rc_background_copy_not_overwrite
     @rc.set('key1', 'val1') #clk = 0
     @rc_replica.set('key1', 'replica1')
     @rc_replica.set('key1', 'replica1') # clk = 1
 
-    send_cmd('localhost_11211', 'switch_replication true localhost_21211')
+    send_cmd('localhost_11211', 'switch_replication true localhost_21211 all')
     sleep 1
 
     assert_equal('replica1', @rc_replica.get('key1'))

--- a/test/t_replication.rb
+++ b/test/t_replication.rb
@@ -97,13 +97,18 @@ class ClusterReplicationTest < Test::Unit::TestCase
   end
 
   def test_rc_switch_replication_error
-    ret = send_cmd('localhost_11211', 'switch_replication true localhost_21211 localhost_21212')
+    ret = send_cmd('localhost_11211', 'switch_replication true localhost_21211 hoge fuga')
     assert_equal("CLIENT_ERROR number of arguments\r\n", ret)
+
+    ret = send_cmd('localhost_11211', 'switch_replication true localhost_21211 false')
+    assert_equal("CLIENT_ERROR [copy target] must be all or nil\r\n", ret)
+
     ret = send_cmd('localhost_11211', 'stat run_replication')
     assert_equal("write-behind.run_replication false\r\n", ret)
 
     ret = send_cmd('localhost_11211', 'switch_replication on localhost_21211')
     assert_equal("CLIENT_ERROR value must be true or false\r\n", ret)
+
     ret = send_cmd('localhost_11211', 'stat run_replication')
     assert_equal("write-behind.run_replication false\r\n", ret)
   end

--- a/test/t_replication.rb
+++ b/test/t_replication.rb
@@ -200,4 +200,28 @@ class ClusterReplicationTest < Test::Unit::TestCase
     assert_equal(4, @rc_replica.get("cnt"))
   end
 
+  def test_rc_background_copy
+    @rc.set('key1', 'val1')
+    @rc.set('key2', 'val2')
+    @rc.set('key3', 'val3')
+
+    send_cmd('localhost_11211', 'switch_replication true localhost_21211')
+    sleep 1
+
+    assert_equal('val1', @rc_replica.get('key1'))
+    assert_equal('val2', @rc_replica.get('key2'))
+    assert_equal('val3', @rc_replica.get('key3'))
+  end
+
+  def test_rc_background_copy_not_overwrite
+    @rc.set('key1', 'val1') #clk = 0
+    @rc_replica.set('key1', 'replica1')
+    @rc_replica.set('key1', 'replica1') # clk = 1
+
+    send_cmd('localhost_11211', 'switch_replication true localhost_21211')
+    sleep 1
+
+    assert_equal('replica1', @rc_replica.get('key1'))
+  end
+
 end #  end of ClusterReplicationTest class

--- a/test/t_replication.rb
+++ b/test/t_replication.rb
@@ -1,0 +1,203 @@
+#!/usr/bin/env ruby
+require 'logger'
+require 'roma/write_behind'
+require 'roma/client/rclient'
+require 'roma/messaging/con_pool'
+
+module StreamWriterTests
+  def setup
+    start_roma
+    @rc = Roma::Client::RomaClient.new(%w(localhost_11211 localhost_11212))
+
+    start_roma_replica
+    @rc_replica = Roma::Client::RomaClient.new(%w(localhost_21211 localhost_21212))
+  end
+
+  def teardown
+    stop_roma
+    stop_roma_replica
+    Roma::Messaging::ConPool.instance.close_all
+  rescue => e
+    puts "#{e} #{$ERROR_POSITION}"
+  end
+
+  def send_cmd(host, cmd)
+    con = Roma::Messaging::ConPool.instance.get_connection(host)
+    con.write("#{cmd}\r\n")
+    ret = con.gets
+    con.close
+    ret
+  end
+end # end of StreamWriterTests module
+
+
+class StreamWriterTest < Test::Unit::TestCase
+  include StreamWriterTests
+  include RomaTestUtils
+
+   def test_sw_get_routing_data
+     sw = Roma::WriteBehind::StreamWriter.new(Logger.new(nil))
+
+     sw.update_mklhash('localhost_21211')
+     pre_mklhash = sw.replica_mklhash
+     assert_match(/[\d\w]{40}/, pre_mklhash)
+
+     sw.update_nodelist('localhost_21211')
+     pre_nodelist = sw.replica_nodelist
+     assert_equal(['localhost_21211', 'localhost_21212'], pre_nodelist)
+
+     sw.update_rttable('localhost_21211')
+     pre_rttable = sw.replica_rttable
+     assert_kind_of(Roma::Routing::RoutingData, pre_rttable)
+   end
+
+   def test_sw_change_mkl_hash?
+     sw = Roma::WriteBehind::StreamWriter.new(Logger.new(nil))
+     sw.replica_mklhash = 'dummy'
+     assert_equal(true, sw.change_mklhash?)
+   end
+
+
+end #  end of StreamWriterTest class
+
+class ClusterReplicationTest < Test::Unit::TestCase
+  include StreamWriterTests
+  include RomaTestUtils
+
+  def test_rc_status
+    ret = send_cmd('localhost_11211', 'stat run_replication')
+    assert_equal("write-behind.run_replication false\r\n", ret)
+
+    ret = send_cmd('localhost_11211', 'stat replica_mklhash')
+    assert_equal("write-behind.replica_mklhash \r\n", ret)
+
+    ret = send_cmd('localhost_11211', 'stat replica_nodelist')
+    assert_equal("write-behind.replica_nodelist []\r\n", ret)
+  end
+
+  def test_rc_switch_replication_default
+    ret = send_cmd('localhost_11211', 'switch_replication true localhost_21211')
+    assert_equal("{\"localhost_11212\"=>\"ACTIVATED\", \"localhost_11211\"=>\"ACTIVATED\"}\r\n", ret)
+    ret = send_cmd('localhost_11211', 'stat run_replication')
+    assert_equal("write-behind.run_replication true\r\n", ret)
+    pre_mklhash = send_cmd('localhost_11211', 'stat replica_mklhash')
+    assert_match(/write-behind\.replica_mklhash [\d\w]{40}\r\n/, pre_mklhash)
+    ret = send_cmd('localhost_11211', 'stat replica_nodelist')
+    assert_equal("write-behind.replica_nodelist [\"localhost_21211\", \"localhost_21212\"]\r\n", ret)
+
+    ret = send_cmd('localhost_11211', 'switch_replication false')
+    assert_equal("{\"localhost_11212\"=>\"DEACTIVATED\", \"localhost_11211\"=>\"DEACTIVATED\"}\r\n", ret)
+    ret = send_cmd('localhost_11211', 'stat run_replication')
+    assert_equal("write-behind.run_replication false\r\n", ret)
+    post_mklhash = send_cmd('localhost_11211', 'stat replica_mklhash')
+    assert_match("write-behind\.replica_mklhash \r\n", post_mklhash)
+    assert_not_equal(pre_mklhash, post_mklhash)
+    ret = send_cmd('localhost_11211', 'stat replica_nodelist')
+    assert_equal("write-behind.replica_nodelist []\r\n", ret)
+  end
+
+  def test_rc_switch_replication_error
+    ret = send_cmd('localhost_11211', 'switch_replication true localhost_21211 localhost_21212')
+    assert_equal("CLIENT_ERROR number of arguments\r\n", ret)
+    ret = send_cmd('localhost_11211', 'stat run_replication')
+    assert_equal("write-behind.run_replication false\r\n", ret)
+
+    ret = send_cmd('localhost_11211', 'switch_replication on localhost_21211')
+    assert_equal("CLIENT_ERROR value must be true or false\r\n", ret)
+    ret = send_cmd('localhost_11211', 'stat run_replication')
+    assert_equal("write-behind.run_replication false\r\n", ret)
+  end
+
+  def test_rc_store_cmd  # get/set/add/replace/append/prepend
+    send_cmd('localhost_11211', 'switch_replication true localhost_21211')
+
+    # set/get
+    @rc.set('key1', 'val1')
+    assert_equal('val1', @rc_replica.get('key1'))
+
+    # add
+    @rc.add('key2', 'val2')
+    assert_equal('val2', @rc_replica.get('key2'))
+    @rc.add("key2", "val3")
+    assert_equal('val2', @rc_replica.get('key2'))
+
+    # replace
+    @rc.set('key3', 'val3')
+    @rc.replace('key3', 'val4')
+    assert_equal('val4', @rc_replica.get('key3'))
+    @rc.replace('key4', 'val4')
+    assert_nil( @rc_replica.get('key4'))
+   
+    # append
+    @rc.set('key5','value5', 0, true)
+    assert_equal('value5', @rc_replica.get('key5', true))
+    @rc.append("key5","_end")
+    assert_equal("value5_end", @rc_replica.get('key5',true))
+
+    # prepend
+    @rc.set('key6','value6', 0, true)
+    assert_equal('value6', @rc_replica.get('key6', true))
+    @rc.prepend("key6","start_")
+    assert_equal("start_value6", @rc_replica.get('key6',true))
+  end
+
+  def test_rc_other_store_cmd # delete/incr/decr/set_expt/cas
+    send_cmd('localhost_11211', 'switch_replication true localhost_21211')
+
+    # delete
+    @rc.set('key1', 'val1')
+    assert_equal('val1', @rc_replica.get('key1'))
+    @rc.delete('key1')
+    assert_nil(@rc_replica.get('key1'))
+
+    # incr
+    @rc.set('key2','100',0,true)
+    assert_equal('100', @rc_replica.get('key2', true))
+    @rc.incr('key2')
+    assert_equal('101', @rc_replica.get('key2', true))
+    @rc.incr('key2', 10)
+    assert_equal('111', @rc_replica.get('key2', true))
+
+    # decr
+    @rc.set('key3','100', 0, true)
+    assert_equal('100', @rc_replica.get('key3', true))
+
+    @rc.decr('key3')
+    assert_equal('99', @rc_replica.get('key3', true))
+
+    @rc.decr('key3', 10)
+    assert_equal('89', @rc_replica.get('key3', true))
+
+    # expt
+    @rc.set('key4', 'val4', 1)
+    assert_equal('val4', @rc_replica.get('key4'))
+    sleep 2
+    assert_nil( @rc_replica.get('key4') )
+
+    # set_expt
+    @rc.set('key5', 'val5')
+    assert_equal('val5', @rc_replica.get('key5'))
+    send_cmd('localhost_11211', 'set_expt key5 1')
+    sleep 2
+    assert_nil( @rc_replica.get('key5') )
+
+    # cas
+    @rc.set("cnt", 1)
+    res = @rc.cas("cnt"){|v|
+      assert_equal(1, v)
+      v += 1
+    }
+    assert_equal(2, @rc_replica.get("cnt"))
+
+    res = @rc.cas("cnt"){|v|
+      res2 = @rc.cas("cnt"){|v2|
+        v += 2
+      }
+      assert_equal("STORED", res2)
+      v += 1
+    }
+    assert_equal("EXISTS", res)
+    assert_equal(4, @rc_replica.get("cnt"))
+  end
+
+end #  end of ClusterReplicationTest class

--- a/test/t_writebehind.rb
+++ b/test/t_writebehind.rb
@@ -209,8 +209,8 @@ class WriteBehindTest < Test::Unit::TestCase
   def teardown
     stop_roma
     Roma::Messaging::ConPool.instance.close_all
-   rescue => e
-     puts "#{e} #{$ERROR_POSITION}"
+  rescue => e
+    puts "#{e} #{$ERROR_POSITION}"
   end
 
   def test_wb2_stat


### PR DESCRIPTION
I implemented cluster replication method.
It is Hot standby function of ROMA cluster.

# How to use
1. boot cluster for replication
2. connect main cluster via telnet
3. execute below command 
~~~~
switch_replication true ${nid}
~~~~

# command
    switch_replication <true|false> [nid] [all]
- nid format is ${host_port}  
  (host is ip or hostname. Adjust your ROMA cluster style.)
- 2nd option require just 1 instance  
  (If you set 1 instance, ROMA check routing information of replica cluster.)
- 3rd option('all') copy the existing data from main to replication cluster  
  (Unless set this option, just copy records after activated cluster replication func.)


# Test
I added test to test/t_replication.rb
~~~~
$ ruby test/run-test.rb -n /test_rc_/
Loaded suite test/run-test
Started
........

Finished in 37.079421056 seconds.
----------------------------------------------------------------------------------------
8 tests, 56 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------
0.22 tests/s, 1.51 assertions/s


$ ruby test/run-test.rb -n /test_sw_/
Loaded suite test/run-test
Started
..

Finished in 6.773633244 seconds.
-----------------------------------------------------------------------------------------------------
2 tests, 4 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------
0.30 tests/s, 0.59 assertions/s
~~~~


And I passed all unit test
~~~~
$ ruby test/run-test.rb

Finished in 1258.171594857 seconds.
-----------------------------------------------------------------------------------------------
405 tests, 10529730 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------
0.32 tests/s, 8369.07 assertions/s
~~~~



# Status
You can get relevant status via stats cmd
~~~~
stat replica
write-behind.run_replication true
write-behind.run_existing_data_replication false
write-behind.replica_mklhash b645bba848c7013ec7357963a1b37d4369c11b37
write-behind.replica_nodelist ["192.168.33.14_10001", "192.168.33.14_10002", "192.168.33.14_10003"]
END
~~~~