### PR TITLE
wip - fix failure about finding tchmgr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
   apt:
     packages:
       - libtokyocabinet-dev
+      - tokyocabinet-bin 
 
 rvm:
   - 2.1.0

--- a/bin/check_tc_flag
+++ b/bin/check_tc_flag
@@ -22,13 +22,15 @@ begin
 
   opts.on("--storage <dir_path>", "Specify the TC Storage directory", "Ex.)/roma/ds/localhost_10001/roma") {|v| options[:storage] = v}
   opts.on("--library <dir_path>", "Specify the TC library directory", "Ex.)/roma/libexec") {|v| options[:library] = v}
+  opts.on("--binary <binary_path>", "Specify the TC mgr command", "Ex.)/usr/bin/tchmgr") {|v| options[:binary] = v}
   opts.parse!(ARGV)
 
   # add default path(current directory)
   options[:storage] = '.' unless options.has_key?(:storage)
   options[:library] = '.' unless options.has_key?(:library)
+  options[:binary]  = ''  unless options.has_key?(:binary)
 
-  tc = Roma::CheckTc.new(options[:storage], options[:library])
+  tc = Roma::CheckTc.new(options[:storage], options[:library], options[:binary])
   res = tc.check_flag
   res.each{|f, flag|
     flag = "(no flag)" if flag.empty?

--- a/lib/roma/tools/check_tc_flag.rb
+++ b/lib/roma/tools/check_tc_flag.rb
@@ -4,16 +4,17 @@ require 'timeout'
 
 module Roma
   class CheckTc
-    def initialize(storage_path, library_path)
+    def initialize(storage_path, library_path, bin_path="")
       @storage_path = storage_path
       @library_path = library_path
+      @bin_path = bin_path.empty? ? "#{@library_path}/bin/tchmgr" : bin_path
     end
 
     def check_flag
       status = {}
       timeout(5){
         Dir.glob("#{@storage_path}/*.tc").each{|f|
-          res = `#{@library_path}/bin/tchmgr inform #{f}`
+          res = `#{@bin_path} inform #{f}`
           res =~ /additional flags:(.*)\n/
           status.store(f, $1)
         }

--- a/test/t_new_func.rb
+++ b/test/t_new_func.rb
@@ -361,11 +361,20 @@ class NewFuncTest < Test::Unit::TestCase
         --storage <dir_path>         Specify the TC Storage directory
                                      Ex.)/roma/ds/localhost_10001/roma
         --library <dir_path>         Specify the TC library directory
-                                     Ex.)/roma/libexec", res.chomp)
+                                     Ex.)/roma/libexec
+        --binary <binary_path>       Specify the TC mgr command
+                                     Ex.)/usr/bin/tchmgr", res.chomp)
 
     start_roma 'cpdbtest/config4cpdb_tc.rb'
     stop_roma
-    res = `#{bin_dir}/check_tc_flag --storage ./localhost_11211/roma --library /usr/local/roma/libexec`
+
+    # If `tchmgr` is system-widly known, use it.
+    # If not, assume it is under the libexec directory.
+    path_tchmgr = `which tchmgr`
+    command_path_tchmgr = "--binary #{path_tchmgr}" if "" != path_tchmgr
+    command_path_tchmgr = "--library /usr/local/roma/libexec" if "" == path_tchmgr
+    res = `#{bin_dir}/check_tc_flag --storage ./localhost_11211/roma #{command_path_tchmgr}`
+
     assert_match(/\.\/localhost_11211\/roma\/\d\.tc : \(no flag\)
 \.\/localhost_11211\/roma\/\d\.tc : \(no flag\)
 \.\/localhost_11211\/roma\/\d\.tc : \(no flag\)


### PR DESCRIPTION
I try to fix the failure caused by the `tchmgr` not under the hardcoded directory. Because on my system, I install TC from `apt-get`. And in project we should allow user to have their TC in different places.