### PR TITLE
fix #136 - Allow ROMA checks `tchmgr`installed in customised place

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
   apt:
     packages:
       - libtokyocabinet-dev
+      - tokyocabinet-bin 
 
 rvm:
   - 2.1.0

--- a/test/t_new_func.rb
+++ b/test/t_new_func.rb
@@ -365,7 +365,17 @@ class NewFuncTest < Test::Unit::TestCase
 
     start_roma 'cpdbtest/config4cpdb_tc.rb'
     stop_roma
-    res = `#{bin_dir}/check_tc_flag --storage ./localhost_11211/roma --library /usr/local/roma/libexec`
+
+    # If `tchmgr` is system-widley known, like installation from `apt-get`,
+    # set the library path as it's parent directory.
+    #
+    # If not, assume it is under the libexec directory.
+    path_tchmgr = `which tchmgr`
+    libpath = File.expand_path(File.join(path_tchmgr.chomp, '..', '..')) if "" != path_tchmgr
+    libpath = "/usr/local/roma/libexec" if "" == path_tchmgr
+
+    res = `#{bin_dir}/check_tc_flag --storage ./localhost_11211/roma --library #{libpath}`
+
     assert_match(/\.\/localhost_11211\/roma\/\d\.tc : \(no flag\)
 \.\/localhost_11211\/roma\/\d\.tc : \(no flag\)
 \.\/localhost_11211\/roma\/\d\.tc : \(no flag\)


### PR DESCRIPTION
As the discussion in

> https://github.com/roma/roma/pull/135

this is the patch to fix the Travis failure and allow ROMA to check `tchmgr` in different places rather than the default one. I will close the old WIP PR if this get review+.