### PR TITLE
Fix failure of test in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 
 sudo: false
+dist: precise
 
 cache: bundler
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ rvm:
   - ruby-head
 
 script:
-  - bundle exec rake test
+  - bundle exec rake test TEST=test/test_replication.rb
   - bundle exec codeclimate-test-reporter
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
-sudo: required
-dist: trusty
+sudo: false
+dist: precise
 
 cache: bundler
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
-sudo: false
-dist: precise
+sudo: required
+dist: trusty
 
 cache: bundler
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ rvm:
   - ruby-head
 
 script:
-  - bundle exec rake test TEST=test/test_replication.rb
+  - bundle exec rake test
   - bundle exec codeclimate-test-reporter
 
 matrix:

--- a/test/test_replication.rb
+++ b/test/test_replication.rb
@@ -68,7 +68,6 @@ class ClusterReplicationTest < Test::Unit::TestCase
 
   def test_rc_status
     ret = send_cmd('localhost_11211', 'stat run_replication')
-    puts ret
     assert_equal("write-behind.run_replication false\r\n", ret)
 
     ret = send_cmd('localhost_11211', 'stat replica_mklhash')

--- a/test/test_replication.rb
+++ b/test/test_replication.rb
@@ -68,6 +68,7 @@ class ClusterReplicationTest < Test::Unit::TestCase
 
   def test_rc_status
     ret = send_cmd('localhost_11211', 'stat run_replication')
+    puts ret
     assert_equal("write-behind.run_replication false\r\n", ret)
 
     ret = send_cmd('localhost_11211', 'stat replica_mklhash')
@@ -109,7 +110,7 @@ class ClusterReplicationTest < Test::Unit::TestCase
     # activate with all data option
     ret = send_cmd('localhost_11211', 'switch_replication true localhost_21211 all')
     assert_equal("{\"localhost_11212\"=>\"ACTIVATED\", \"localhost_11211\"=>\"ACTIVATED\"}\r\n", ret)
-    # run_existing_data_replication status 
+    # run_existing_data_replication status
     ret = send_cmd('localhost_11211', 'stat run_existing_data_replication')
     assert_equal("write-behind.run_existing_data_replication true\r\n", ret)
 
@@ -171,7 +172,7 @@ class ClusterReplicationTest < Test::Unit::TestCase
     @rc.replace('key4', 'val4')
     sleep 0.1
     assert_nil( @rc_replica.get('key4'))
-   
+
     # append
     @rc.set('key5','value5', 0, true)
     sleep 0.1


### PR DESCRIPTION
I found that last success build was performed on Precise but all recent failures were done on Trusty. 
This PR provides updates to specify to use precise in Travis CI.

But [the default dist is Trusty](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status). 